### PR TITLE
Convert dictionary values in submit()

### DIFF
--- a/kcidb/__init__.py
+++ b/kcidb/__init__.py
@@ -123,6 +123,8 @@ class Client:
                     # Flatten the "misc" fields
                     if key == "misc":
                         node[key] = json.dumps(value)
+                    else:
+                        node[key] = convert_node(value)
             return node
 
         io_schema.validate(data)


### PR DESCRIPTION
Not only flatten the "misc" fields, but also convert the values to
BigQuery representation in Client.submit(). This fixes flattening deeper
"misc" fields, such as in test environments.