### PR TITLE
schema: add compiler field to build

### DIFF
--- a/kcidb/db_schema.py
+++ b/kcidb/db_schema.py
@@ -146,6 +146,11 @@ TABLE_MAP = dict(
                         "including environment variables",
         ),
         Field(
+            "compiler", "STRING",
+            description="Name and version of the compiler used to make the "
+                        "build",
+        ),
+        Field(
             "input_files", "RECORD", mode="REPEATED", fields=RESOURCE_FIELDS,
             description="A list of build input files. E.g. configuration.",
         ),

--- a/kcidb/io_schema.py
+++ b/kcidb/io_schema.py
@@ -223,6 +223,11 @@ JSON_BUILD = {
                 "Full shell command line used to make the build, "
                 "including environment variables",
         },
+        "compiler": {
+            "type": "string",
+            "description":
+                "Name and version of the compiler used to make the build",
+        },
         "input_files": {
             "type": "array",
             "description":


### PR DESCRIPTION
Add a "compiler" field to the build schema with description.  This is
a plain string to identify the compiler used with its version.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>