### PR TITLE
schema: add config_name, config_url

### DIFF
--- a/kcidb/db_schema.py
+++ b/kcidb/db_schema.py
@@ -159,6 +159,14 @@ TABLE_MAP = dict(
             description="A list of build output files: images, packages, etc.",
         ),
         Field(
+            "config_name", "STRING",
+            description="A name describing the build configuration options.",
+        ),
+        Field(
+            "config_url", "STRING",
+            description="The URL of the build configuration file.",
+        ),
+        Field(
             "log_url", "STRING",
             description="The URL of the build log file.",
         ),

--- a/kcidb/io_schema.py
+++ b/kcidb/io_schema.py
@@ -240,6 +240,17 @@ JSON_BUILD = {
                 "A list of build output files: images, packages, etc.",
             "items": JSON_RESOURCE,
         },
+        "config_name": {
+            "type": "string",
+            "description":
+                "A name describing the build configuration options.",
+        },
+        "config_url": {
+            "type": "string",
+            "format": "uri",
+            "description":
+                "The URL of the build configuration file.",
+        },
         "log_url": {
             "type": "string",
             "format": "uri",


### PR DESCRIPTION
Add new config_name and config_url fields for describing kernel config
options (aka defconfig) used to build the kernel, and providing a URL
to reference the full config file.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>