### PR TITLE
Separate user and admin interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 KCIDB
 =====
 
-Kcidb is a package for entering and querying data to/from kernelci.org test
-execution database.
+Kcidb is a package for entering and querying data to/from the Linux Kernel CI
+common report database.
 
 Setup
 -----

--- a/kcidb/__init__.py
+++ b/kcidb/__init__.py
@@ -228,13 +228,13 @@ def validate_main():
     try:
         data = json.load(sys.stdin)
     except json.decoder.JSONDecodeError as err:
-        print(err, sys.stderr)
+        print(err, file=sys.stderr)
         return 1
 
     try:
         io_schema.validate(data)
     except jsonschema.exceptions.ValidationError as err:
-        print(err, sys.stderr)
+        print(err, file=sys.stderr)
         return 2
     return 0
 
@@ -253,13 +253,13 @@ def tests_validate_main():
     try:
         catalog = yaml.safe_load(sys.stdin)
     except yaml.YAMLError as err:
-        print(err, sys.stderr)
+        print(err, file=sys.stderr)
         return 1
 
     try:
         tests_schema.validate(catalog)
     except jsonschema.exceptions.ValidationError as err:
-        print(err, sys.stderr)
+        print(err, file=sys.stderr)
         return 2
 
     if args.urls:
@@ -267,7 +267,7 @@ def tests_validate_main():
             for test in catalog.values():
                 requests.head(test['home']).raise_for_status()
         except requests.RequestException as err:
-            print(err, sys.stderr)
+            print(err, file=sys.stderr)
             return 3
 
     return 0

--- a/kcidb/__init__.py
+++ b/kcidb/__init__.py
@@ -1,4 +1,4 @@
-"""Kernel CI database management"""
+"""Kernel CI reporting"""
 
 import argparse
 import decimal
@@ -16,11 +16,11 @@ from kcidb import tests_schema
 
 
 class Client:
-    """Kernel CI database client"""
+    """Kernel CI report database client"""
 
     def __init__(self, dataset_name):
         """
-        Initialize a Kernel CI database client.
+        Initialize a Kernel CI report database client.
 
         Args:
             dataset_name:   The name of the Kernel CI dataset. The dataset
@@ -155,7 +155,8 @@ class Client:
 
 def query_main():
     """Execute the kcidb-query command-line tool"""
-    description = 'kcidb-query - Query test results from kernelci.org database'
+    description = \
+        'kcidb-query - Query reports from Kernel CI report database'
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
         '-d', '--dataset',
@@ -169,7 +170,8 @@ def query_main():
 
 def submit_main():
     """Execute the kcidb-submit command-line tool"""
-    description = 'kcidb-submit - Submit test results to kernelci.org database'
+    description = \
+        'kcidb-submit - Submit reports to Kernel CI report database'
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
         '-d', '--dataset',
@@ -185,7 +187,7 @@ def submit_main():
 
 def init_main():
     """Execute the kcidb-init command-line tool"""
-    description = 'kcidb-init - Initialize a kernelci.org database'
+    description = 'kcidb-init - Initialize a Kernel CI report database'
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
         '-d', '--dataset',
@@ -199,7 +201,7 @@ def init_main():
 
 def cleanup_main():
     """Execute the kcidb-cleanup command-line tool"""
-    description = 'kcidb-cleanup - Cleanup a kernelci.org database'
+    description = 'kcidb-cleanup - Cleanup a Kernel CI report database'
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument(
         '-d', '--dataset',

--- a/kcidb/io_schema.py
+++ b/kcidb/io_schema.py
@@ -432,8 +432,8 @@ JSON_TEST = {
 JSON = {
     "title": "kcidb",
     "description":
-        "Kernelci.org test data. To be submitted to/queried from the common "
-        "test report database.\n"
+        "Kernel CI report data. To be submitted to/queried from the common "
+        "report database.\n"
         "\n"
         "Objects in the data are identified and linked together using two "
         "properties: \"origin\" and \"origin_id\". The former is a string "

--- a/setup.py
+++ b/setup.py
@@ -52,12 +52,14 @@ setuptools.setup(
     ),
     entry_points=dict(
         console_scripts=[
-            "kcidb-init = kcidb:init_main",
-            "kcidb-cleanup = kcidb:cleanup_main",
             "kcidb-schema = kcidb:schema_main",
             "kcidb-validate = kcidb:validate_main",
             "kcidb-submit = kcidb:submit_main",
             "kcidb-query = kcidb:query_main",
+            "kcidb-db-init = kcidb:db_init_main",
+            "kcidb-db-cleanup = kcidb:db_cleanup_main",
+            "kcidb-db-load = kcidb:db_load_main",
+            "kcidb-db-query = kcidb:db_query_main",
             "kcidb-tests-validate = kcidb:tests_validate_main",
         ]
     )

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     python_requires=">=3.6",
     author="kernelci.org",
     author_email="kernelci@groups.io",
-    description="KCIDB = kernelci.org database tools",
+    description="KCIDB = Linux Kernel CI reporting tools",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/spbnick/kcidb",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="kcidb",
-    version="1",
+    version="3",
     python_requires=">=3.6",
     author="kernelci.org",
     author_email="kernelci@groups.io",


### PR DESCRIPTION
Beside a few small fixes, this mainly deals with separating the user and administrator interfaces. The former is abstracted from the implementation and only has two operations ("submit" and "query"), while the latter goes (will go) into details and deals with infrastructure directly.