### PR TITLE
Support query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ To upgrade the dataset schema, do the following.
 4. Disable write access to the old dataset using BigQuery management console.
 
 5. Transfer data from the old dataset (named `kernelci01` here) to the new
-   dataset (named `kernelci02` here) using old-schema `kcidb-db-query` and
+   dataset (named `kernelci02` here) using old-schema `kcidb-db-dump` and
    new-schema `kcidb-db-load`.
 
         # Using old-schema kcidb
-        kcidb-db-query -d kernelci01 > kernelci01.json
+        kcidb-db-dump -d kernelci01 > kernelci01.json
         # Using new-schema kcidb
         kcidb-db-load -d kernelci02 < kernelci01.json
 

--- a/kcidb/__init__.py
+++ b/kcidb/__init__.py
@@ -39,14 +39,26 @@ class Client:
         assert io.schema.is_valid(data)
         self.db_client.load(data)
 
-    def query(self):
+    def query(self, patterns, children=False, parents=False):
         """
-        Query reports.
+        Match and fetch report objects.
+
+        Args:
+            patterns:   A dictionary of object list names, and lists of LIKE
+                        patterns, for IDs of objects to match.
+            children:   True if children of matched objects should be matched
+                        as well.
+            parents:    True if parents of matched objects should be matched
+                        as well.
 
         Returns:
-            The JSON report data adhering to the latest I/O schema.
+            The fetched JSON data adhering to the latest I/O schema version.
+
+        Raises:
+            `IncompatibleSchema` if the dataset schema is incompatible with
+            the latest I/O schema.
         """
-        data = self.db_client.query()
+        data = self.db_client.query(patterns, children, parents)
         assert io.schema.is_valid_latest(data)
         return data
 
@@ -70,17 +82,7 @@ def submit_main():
 
 def query_main():
     """Execute the kcidb-query command-line tool"""
-    description = \
-        'kcidb-query - Query Kernel CI reports'
-    parser = argparse.ArgumentParser(description=description)
-    parser.add_argument(
-        '-d', '--dataset',
-        help='Dataset name',
-        required=True
-    )
-    args = parser.parse_args()
-    client = db.Client(args.dataset)
-    json.dump(client.query(), sys.stdout, indent=4, sort_keys=True)
+    return db.query_main("kcidb-query - Query Kernel CI reports")
 
 
 def schema_main():

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setuptools.setup(
             "kcidb-db-init = kcidb.db:init_main",
             "kcidb-db-cleanup = kcidb.db:cleanup_main",
             "kcidb-db-load = kcidb.db:load_main",
+            "kcidb-db-dump = kcidb.db:dump_main",
             "kcidb-db-query = kcidb.db:query_main",
             "kcidb-db-complement = kcidb.db:complement_main",
             "kcidb-mq-publisher-init = kcidb.mq:publisher_init_main",


### PR DESCRIPTION
Support specifying ID LIKE patterns for all report object types when
querying. Support requesting all linked parents and/or children as well.

This concerns both `kcidb-db-query` and `kcidb-query` tools. The latter
becomes an actual alias to the former for the current implementation.
This also concerns the kcidb.Client.query() function, although nothing
uses it yet.

Since LIKE patterns are not very efficient compared to unconditional
queries and since interface becomes non-trivial, add `kcidb-db-dump`
tool which does exactly what `kcidb-db-query` did before - just dump the
complete database.