### PR TITLE
move kdump url to top level

### DIFF
--- a/tests.yaml
+++ b/tests.yaml
@@ -182,7 +182,7 @@ redhat_kaslr:
   home: https://github.com/CKI-project/tests-beaker/tree/master/memory/function/kaslr
 redhat_kdump:
   title: Red Hat's kdump tests
-  home: https://github.com/CKI-project/tests-beaker/tree/master/kdump/kdump-sysrq-c
+  home: https://github.com/CKI-project/tests-beaker/tree/master/kdump
 redhat_l2tp:
   title: Red Hat's basic L2TP tests
   home: https://github.com/CKI-project/tests-beaker/tree/master/networking/tunnel/l2tp/basic


### PR DESCRIPTION
kdump is now a suite of tests as we are onboarding new tests which
are part of kdump, change the url to point to the top level directory
to make it apparent that it's now a suite.