### PR TITLE
io.schema: Remove "repository" from "commit"

### DIFF
--- a/kcidb/io/schema/test_v3.py
+++ b/kcidb/io/schema/test_v3.py
@@ -61,3 +61,34 @@ class UpgradeTestCase(unittest.TestCase):
         )
 
         self.assertEqual(VERSION.upgrade(prev_version_data), new_version_data)
+
+    def test_repository_commit_rename(self):
+        """Check git_repository_commit* rename to git_commit* works"""
+        prev_version_data = dict(
+            version=dict(major=VERSION.previous.major,
+                         minor=VERSION.previous.minor),
+            revisions=[
+                dict(id="origin1:5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                     git_repository_commit_hash="5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                     git_repository_commit_name="foo"),
+                dict(id="origin2:41f53451e75df9864a78c83e935e98ede7a170c2",
+                     git_repository_commit_hash="41f53451e75df9864a78c83e935e98ede7a170c2",
+                     git_repository_commit_name="bar"),
+            ],
+        )
+        new_version_data = dict(
+            version=dict(major=VERSION.major,
+                         minor=VERSION.minor),
+            revisions=[
+                dict(id="5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                     origin="origin1",
+                     git_commit_hash="5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                     git_commit_name="foo"),
+                dict(id="41f53451e75df9864a78c83e935e98ede7a170c2",
+                     origin="origin2",
+                     git_commit_hash="41f53451e75df9864a78c83e935e98ede7a170c2",
+                     git_commit_name="bar"),
+            ],
+        )
+
+        self.assertEqual(VERSION.upgrade(prev_version_data), new_version_data)

--- a/kcidb/io/schema/v3.py
+++ b/kcidb/io/schema/v3.py
@@ -22,11 +22,11 @@ SHA256_PATTERN = "[0-9a-f]{64}"
 
 # A regular expression pattern matching strings containing Git repository
 # commit hash (sha1)
-GIT_REPOSITORY_COMMIT_HASH_PATTERN = f"{SHA1_PATTERN}"
+GIT_COMMIT_HASH_PATTERN = f"{SHA1_PATTERN}"
 
 # A regular expression pattern matching strings containing revision IDs
 REVISION_ID_PATTERN = \
-    f"{GIT_REPOSITORY_COMMIT_HASH_PATTERN}" \
+    f"{GIT_COMMIT_HASH_PATTERN}" \
     f"(\\+{SHA256_PATTERN})?"
 
 # A regular expression pattern matching strings containing origin name
@@ -139,14 +139,13 @@ JSON_REVISION = {
                 "that's not available, the shortest possible git:// URL.",
             "pattern": f"^{GIT_REPOSITORY_URL_PATTERN}$",
         },
-        "git_repository_commit_hash": {
+        "git_commit_hash": {
             "type": "string",
             "description":
-                "The full commit hash of the revision's base code "
-                "in the Git repository",
-            "pattern": f"^{GIT_REPOSITORY_COMMIT_HASH_PATTERN}$",
+                "The full commit hash of the revision's base code",
+            "pattern": f"^{GIT_COMMIT_HASH_PATTERN}$",
         },
-        "git_repository_commit_name": {
+        "git_commit_name": {
             "type": "string",
             "description":
                 "A human-readable name of the commit containing the base "
@@ -606,6 +605,13 @@ def inherit(data):
         revision["id"] = remove_origin(revision["id"])
     for build in data.get("builds", []):
         build["revision_id"] = remove_origin(build["revision_id"])
+
+    # Rename git_repository_commit* to git_commit* in revisions
+    for revision in data.get("revisions", []):
+        for old, new in (("git_repository_commit_hash", "git_commit_hash"),
+                         ("git_repository_commit_name", "git_commit_name")):
+            if old in revision:
+                revision[new] = revision.pop(old)
 
     # Update version
     data['version'] = dict(major=JSON_VERSION_MAJOR,

--- a/kcidb/test_misc.py
+++ b/kcidb/test_misc.py
@@ -35,7 +35,7 @@ class NotificationTestCase(unittest.TestCase):
                     ],
                     "discovery_time": "2020-03-02T15:16:15.790000+00:00",
                     "git_repository_branch": "wip/jgg-for-next",
-                    "git_repository_commit_hash": "5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                    "git_commit_hash": "5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
                     "git_repository_url": "git://git.kernel.org/pub/scm/linux/kernel/git/rdma/rdma.git",
                     "misc": {
                         "pipeline_id": 467715

--- a/kcidb/test_oo.py
+++ b/kcidb/test_oo.py
@@ -70,7 +70,7 @@ class FromIOTestCase(unittest.TestCase):
                     ],
                     "discovery_time": "2020-03-02T15:16:15.790000+00:00",
                     "git_repository_branch": "wip/jgg-for-next",
-                    "git_repository_commit_hash": "5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                    "git_commit_hash": "5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
                     "git_repository_url": "git://git.kernel.org/pub/scm/linux/kernel/git/rdma/rdma.git",
                     "misc": {
                         "pipeline_id": 467715
@@ -93,7 +93,7 @@ class FromIOTestCase(unittest.TestCase):
                     ],
                     "discovery_time": "2020-03-02T15:16:15.790000+00:00",
                     "git_repository_branch": "wip/jgg-for-next",
-                    "git_repository_commit_hash": "5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                    "git_commit_hash": "5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
                     "git_repository_url": "git://git.kernel.org/pub/scm/linux/kernel/git/rdma/rdma.git",
                     "misc": {
                         "pipeline_id": 467715

--- a/kcidb/test_subscriptions.py
+++ b/kcidb/test_subscriptions.py
@@ -35,7 +35,7 @@ class MatchOOTestCase(unittest.TestCase):
                     ],
                     "discovery_time": "2020-03-02T15:16:15.790000+00:00",
                     "git_repository_branch": "wip/jgg-for-next",
-                    "git_repository_commit_hash": "5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
+                    "git_commit_hash": "5e29d1443c46b6ca70a4c940a67e8c09f05dcb7e",
                     "git_repository_url": "git://git.kernel.org/pub/scm/linux/kernel/git/rdma/rdma.git",
                     "misc": {
                         "pipeline_id": 467715
@@ -51,7 +51,7 @@ class MatchOOTestCase(unittest.TestCase):
                     ],
                     "discovery_time": "2020-03-02T15:16:15.790000+00:00",
                     "git_repository_branch": "wip/jgg-for-next",
-                    "git_repository_commit_hash": "1254e88b4fc1470d152f494c3590bb6a33ab33eb",
+                    "git_commit_hash": "1254e88b4fc1470d152f494c3590bb6a33ab33eb",
                     "git_repository_url": "git://git.kernel.org/pub/scm/linux/kernel/git/rdma/rdma.git",
                     "misc": {
                         "pipeline_id": 467715


### PR DESCRIPTION
Rename git_repository_commit* revision fields to git_commit*, in v3 I/O schema.

Fixes #85.