### PR TITLE
Add origin_url field

### DIFF
--- a/kcidb/db/schema.py
+++ b/kcidb/db/schema.py
@@ -14,6 +14,10 @@ RESOURCE_FIELDS = (
 # Test environment fields
 ENVIRONMENT_FIELDS = (
     Field(
+        "origin_url", "STRING",
+        description="The URL of the environment in the origin CI system",
+    ),
+    Field(
         "description", "STRING",
         description="Human-readable description of the environment",
     ),
@@ -35,6 +39,10 @@ TABLE_MAP = dict(
             "origin", "STRING",
             description="The name of the CI system which submitted "
                         "the revision",
+        ),
+        Field(
+            "origin_url", "STRING",
+            description="The URL of the revision in the origin CI system",
         ),
         Field(
             "tree_name", "STRING",
@@ -129,6 +137,10 @@ TABLE_MAP = dict(
                         "the build",
         ),
         Field(
+            "origin_url", "STRING",
+            description="The URL of the build in the origin CI system",
+        ),
+        Field(
             "description", "STRING",
             description="Human-readable description of the build",
         ),
@@ -198,6 +210,10 @@ TABLE_MAP = dict(
             "origin", "STRING",
             description="The name of the CI system which submitted "
                         "the test run",
+        ),
+        Field(
+            "origin_url", "STRING",
+            description="The URL of the test run in the origin CI system",
         ),
         Field(
             "environment", "RECORD", fields=ENVIRONMENT_FIELDS,

--- a/kcidb/io/schema/v3.py
+++ b/kcidb/io/schema/v3.py
@@ -119,6 +119,11 @@ JSON_REVISION = {
                 "The name of the CI system which submitted the revision",
             "pattern": f"^{ORIGIN_PATTERN}$",
         },
+        "origin_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL of the revision in the origin CI system",
+        },
         "tree_name": {
             "type": "string",
             "description":
@@ -265,6 +270,15 @@ JSON_BUILD = {
                 "The name of the CI system which submitted the build",
             "pattern": f"^{ORIGIN_PATTERN}$",
         },
+        "origin_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL of the build in the origin CI system",
+            "examples": [
+                "https://kernelci.org/build/net-next/branch/master/"
+                "kernel/v5.8-rc4-1414-g4ff91fa0a3ac/",
+            ],
+        },
         "description": {
             "type": "string",
             "description":
@@ -389,6 +403,14 @@ JSON_TEST = {
                 "The name of the CI system which submitted the test run",
             "pattern": f"^{ORIGIN_PATTERN}$",
         },
+        "origin_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "The URL of the test run in the origin CI system",
+            "examples": [
+                "https://kernelci.org/test/case/id/5f0e86fc459ceb8c2885bb39/",
+            ],
+        },
         "environment": {
             "type": "object",
             "description":
@@ -397,6 +419,13 @@ JSON_TEST = {
                 "amount of memory/storage/CPUs, for each host; "
                 "process environment variables, etc.",
             "properties": {
+                "origin_url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description":
+                        "The URL of the environment in the origin CI system",
+                    "examples": ["https://kernelci.org/soc/allwinner/"],
+                },
                 "description": {
                     "type": "string",
                     "description":


### PR DESCRIPTION
Add an "origin_url" field to every schema object, pointing to the object
within, and served by, the origin CI system.

Fixes #93