### PR TITLE
Print full exception stack on errors

### DIFF
--- a/kcidb/__init__.py
+++ b/kcidb/__init__.py
@@ -185,13 +185,13 @@ def validate_main():
     try:
         data = json.load(sys.stdin)
     except json.decoder.JSONDecodeError as err:
-        print(err, file=sys.stderr)
+        print(misc.format_exception_stack(err), file=sys.stderr)
         return 1
 
     try:
         io.schema.validate(data)
     except jsonschema.exceptions.ValidationError as err:
-        print(err, file=sys.stderr)
+        print(misc.format_exception_stack(err), file=sys.stderr)
         return 2
     return 0
 
@@ -205,13 +205,13 @@ def upgrade_main():
     try:
         data = json.load(sys.stdin)
     except json.decoder.JSONDecodeError as err:
-        print(err, file=sys.stderr)
+        print(misc.format_exception_stack(err), file=sys.stderr)
         return 1
 
     try:
         data = io.schema.upgrade(data, copy=False)
     except jsonschema.exceptions.ValidationError as err:
-        print(err, file=sys.stderr)
+        print(misc.format_exception_stack(err), file=sys.stderr)
         return 2
 
     json.dump(data, sys.stdout, indent=4, sort_keys=True)
@@ -291,10 +291,10 @@ def merge_main():
                 data = io.schema.validate(json.load(json_file))
             io.merge(merged_data, data, copy_target=False, copy_source=False)
         except json.decoder.JSONDecodeError as err:
-            print(err, file=sys.stderr)
+            print(misc.format_exception_stack(err), file=sys.stderr)
             return 1
         except jsonschema.exceptions.ValidationError as err:
-            print(err, file=sys.stderr)
+            print(misc.format_exception_stack(err), file=sys.stderr)
             return 2
 
     json.dump(merged_data, sys.stdout, indent=4, sort_keys=True)
@@ -327,7 +327,7 @@ def notify_main():
         except (json.decoder.JSONDecodeError,
                 jsonschema.exceptions.ValidationError) as err:
             print("Failed reading base file:", file=sys.stderr)
-            print(err, file=sys.stderr)
+            print(misc.format_exception_stack(err), file=sys.stderr)
             return 1
 
     try:
@@ -336,7 +336,7 @@ def notify_main():
     except (json.decoder.JSONDecodeError,
             jsonschema.exceptions.ValidationError) as err:
         print("Failed reading new file:", file=sys.stderr)
-        print(err, file=sys.stderr)
+        print(misc.format_exception_stack(err), file=sys.stderr)
         return 1
 
     for notification in subscriptions.match_new_io(base, new):

--- a/kcidb/misc.py
+++ b/kcidb/misc.py
@@ -4,6 +4,7 @@ import re
 import base64
 import argparse
 import logging
+from textwrap import indent
 from email.message import EmailMessage
 from google.cloud import secretmanager
 from kcidb.io import schema
@@ -48,6 +49,30 @@ def logging_setup(level):
     # TODO Consider separate arguments for controlling the below
     logging.getLogger("urllib3").setLevel(LOGGING_LEVEL_MAP["NONE"])
     logging.getLogger("google").setLevel(LOGGING_LEVEL_MAP["NONE"])
+
+
+def format_exception_stack(exc):
+    """
+    Format an exception's context stack as a series of indented messages.
+
+    Args:
+        exc:    The exception to format the stack of.
+
+    Returns:
+        The formatted exception stack.
+    """
+    assert isinstance(exc, Exception)
+    string = ""
+    prefix = ""
+    while True:
+        string += indent(str(exc), prefix)
+        if exc.__context__:
+            string += ":\n"
+            prefix += "  "
+            exc = exc.__context__
+        else:
+            break
+    return string
 
 
 class ArgumentParser(argparse.ArgumentParser):

--- a/kcidb/tests/__init__.py
+++ b/kcidb/tests/__init__.py
@@ -5,6 +5,7 @@ import sys
 import yaml
 import requests
 import jsonschema
+from kcidb import misc
 from kcidb.tests import schema
 
 
@@ -22,13 +23,13 @@ def validate_main():
     try:
         catalog = yaml.safe_load(sys.stdin)
     except yaml.YAMLError as err:
-        print(err, file=sys.stderr)
+        print(misc.format_exception_stack(err), file=sys.stderr)
         return 1
 
     try:
         schema.validate(catalog)
     except jsonschema.exceptions.ValidationError as err:
-        print(err, file=sys.stderr)
+        print(misc.format_exception_stack(err), file=sys.stderr)
         return 2
 
     if args.urls:
@@ -36,7 +37,7 @@ def validate_main():
             for test in catalog.values():
                 requests.head(test['home']).raise_for_status()
         except requests.RequestException as err:
-            print(err, file=sys.stderr)
+            print(misc.format_exception_stack(err), file=sys.stderr)
             return 3
 
     return 0


### PR DESCRIPTION
Instead of printing just the latest exception, print the whole exception context stack when printing errors. This gives the full context to the user, and most importantly produces schema validation errors for *all* schema versions not only the oldest one, which is often just about the version mismatch.