### PR TITLE
Provide and use a way to wait for publishing

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,7 +65,7 @@ def kcidb_load_message(event, context):
     # Store it in the database
     DB_CLIENT.load(data)
     # Forward the data to the "loaded" MQ topic
-    LOADED_QUEUE_PUBLISHER.publish(data)
+    LOADED_QUEUE_PUBLISHER.publish(data).result()
 
 
 def kcidb_load_queue_msgs(subscriber, msg_max, obj_max, timeout_sec):
@@ -179,7 +179,7 @@ def kcidb_load_queue(event, context):
     LOGGER.debug("ACK'ed %u messages", len(msgs))
 
     # Forward the loaded data to the "loaded" topic
-    LOADED_QUEUE_PUBLISHER.publish(data)
+    LOADED_QUEUE_PUBLISHER.publish(data).result()
     LOGGER.info("Forwarded %u objects", obj_num)
 
 

--- a/test_kcidb.py
+++ b/test_kcidb.py
@@ -43,7 +43,9 @@ class KCIDBMainFunctionsTestCase(kcidb.unittest.TestCase):
         driver_source = textwrap.dedent(f"""
             from unittest.mock import patch, Mock
             client = Mock()
-            client.submit = Mock()
+            future = Mock()
+            future.result = Mock(return_value="id")
+            client.submit = Mock(return_value=future)
             with patch("kcidb.Client", return_value=client) as Client:
                 status = function()
             Client.assert_called_once_with(project_id="project",
@@ -52,12 +54,15 @@ class KCIDBMainFunctionsTestCase(kcidb.unittest.TestCase):
             return status
         """)
         self.assertExecutes(json.dumps(empty), *argv,
-                            driver_source=driver_source)
+                            driver_source=driver_source,
+                            stdout_re="id\n")
 
         driver_source = textwrap.dedent(f"""
             from unittest.mock import patch, Mock, call
             client = Mock()
-            client.submit = Mock()
+            future = Mock()
+            future.result = Mock(return_value="id")
+            client.submit = Mock(return_value=future)
             with patch("kcidb.Client", return_value=client) as Client:
                 status = function()
             Client.assert_called_once_with(project_id="project",
@@ -68,7 +73,8 @@ class KCIDBMainFunctionsTestCase(kcidb.unittest.TestCase):
             return status
         """)
         self.assertExecutes(json.dumps(empty) + json.dumps(empty), *argv,
-                            driver_source=driver_source)
+                            driver_source=driver_source,
+                            stdout_re="id\nid\n")
 
     def test_query_main(self):
         """Check kcidb-query works"""


### PR DESCRIPTION
Return publishing "futures" whenever publishing to a message queue, and
use that to make sure the messages actually got there. Output the
resulting publishing IDs in command-line tools. This fixes sporadic
message loss, especially with JSON streams.