### PR TITLE
Add storage block fs fio and queue scheduler tests to kcidb catalog

### DIFF
--- a/tests.yaml
+++ b/tests.yaml
@@ -111,6 +111,12 @@ redhat_apache_mod_ssl:
 redhat_autofs_connectathon:
   title: Red Hat's version of AutoFS connectathon test suite
   home: https://gitlab.com/cki-project/kernel-tests/-/tree/master/autofs/connectathon
+redhat_block_fs_fio:
+  title: Red Hat's Storage block filesystem fio tests
+  home: https://gitlab.com/cki-project/kernel-tests/-/tree/master/storage/block/fs_fio
+redhat_block_mq_sche:
+  title: Red Hat's Storage block queue scheduler tests
+  home: https://gitlab.com/cki-project/kernel-tests/-/tree/master/storage/block/mq_sche
 redhat_bridge:
   title: Red Hat's Ethernet bridge tests
   home: https://gitlab.com/cki-project/kernel-tests/-/tree/master/networking/bridge/sanity_check


### PR DESCRIPTION
RH recently onboarded two storage block tests, one for filesystem fio and other for queue scheduler, please add this test descriptons to the KCIDB catalog.