### PR TITLE
Update to stream-enabled jq 1.1.2 with fixed version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ requests
 pyyaml
 jinja2
 python-dateutil
-jq@git+https://github.com/spbnick/jq.py.git@1.0.3spbnick1
+jq@git+https://github.com/spbnick/jq.py.git@1.1.2.post1
 kcidb-io@git+https://github.com/kernelci/kcidb-io.git@v2

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setuptools.setup(
         "pyyaml",
         "jinja2",
         "python-dateutil",
-        "jq@git+https://github.com/spbnick/jq.py.git@1.0.3spbnick1",
+        "jq@git+https://github.com/spbnick/jq.py.git@1.1.2.post1",
         "kcidb-io@git+https://github.com/kernelci/kcidb-io.git@v2",
     ],
     extras_require=dict(


### PR DESCRIPTION
Update to our fork of jq rebased on the upstream 1.1.2 release, also
using a PEP 440-compliant version number, which fixes installation with
recent pip versions.