### PR TITLE
db: Add is_initialized() to null driver

### DIFF
--- a/kcidb/db/null/__init__.py
+++ b/kcidb/db/null/__init__.py
@@ -25,13 +25,21 @@ class Driver(AbstractDriver):
         if params is not None:
             raise Exception("Database parameters are not accepted")
 
+    def is_initialized(self):
+        """
+        Check if the database is initialized (not empty).
+
+        Returns:
+            True if the database is initialized, False otherwise.
+        """
+        return True
+
     def get_schema_version(self):
         """
         Get the version of the I/O schema the dataset schema corresponds to.
 
         Returns:
-            Major and minor version numbers,
-            or (None, None) if the database is uninitialized.
+            Major and minor version numbers.
         """
         return io.schema.LATEST.major, io.schema.LATEST.minor
 


### PR DESCRIPTION
Split get_schema_version() into the new get_schema_version() and
is_initialized() in the "null" database driver. This follows the change
all the other drivers got earlier and "null" was forgotten.

This fixes actually using the "null" driver which would otherwise fail
with a message like this:

    Exception: Failed connecting to 'null' database:
      TypeError: Can't instantiate abstract class Driver with abstract method is_initialized