### PR TITLE
Upgrade to previous or latest I/O data schema

### DIFF
--- a/kcidb/__init__.py
+++ b/kcidb/__init__.py
@@ -259,13 +259,22 @@ def validate_main():
 def upgrade_main():
     """Execute the kcidb-upgrade command-line tool"""
     sys.excepthook = misc.log_and_print_excepthook
-    description = 'kcidb-upgrade - Upgrade I/O JSON data to latest schema'
+    description = 'kcidb-upgrade - Upgrade I/O JSON data to a valid previous schema or latest schema'
     parser = misc.OutputArgumentParser(description=description)
+    parser.add_argument(
+            'target',
+            metavar="TARGET-SCHEMA",
+            nargs='?',
+            type=int,
+            default=4,
+            choices=[1,2,3,4],
+            help='Upgrade to a valid target schema. Default is latest schema.'
+    )
     args = parser.parse_args()
 
     misc.json_dump_stream(
         (
-            io.schema.upgrade(io.schema.validate(data), copy=False)
+            io.schema.upgrade(args.target, io.schema.validate(data), copy=False)
             for data in misc.json_load_stream_fd(sys.stdin.fileno())
         ),
         sys.stdout, indent=args.indent, seq=args.seq


### PR DESCRIPTION
This pull request fixes the issue #79 
Add an optional positional CLI argument to `kcidb-upgrade` tool for upgrading to a valid JSON `target-schema` I/O data schema. The option has a default value of `4`, which is the latest JSON I/O data schema according to `kcidb-io` module.