### PR TITLE
Revert "Upgrade google-cloud pubsub"

### DIFF
--- a/kcidb/mq/__init__.py
+++ b/kcidb/mq/__init__.py
@@ -65,7 +65,7 @@ class Publisher(ABC):
         """
         Initialize publishing setup.
         """
-        self.client.create_topic(name=self.topic_path)
+        self.client.create_topic(self.topic_path)
 
     def cleanup(self):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Pip requirements for Google Cloud Functions.
 # Must match install_requires from setup.py.
 google-cloud-bigquery
-google-cloud-pubsub
+google-cloud-pubsub<2.0.0dev
 google-cloud-firestore
 google-cloud-secret-manager
 importlib_metadata

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
     # Let's make that easier, pylint: disable=line-too-long
     install_requires=[
         "google-cloud-bigquery",
-        "google-cloud-pubsub",
+        "google-cloud-pubsub<2.0.0dev",
         "google-cloud-firestore",
         "google-cloud-secret-manager",
         # TODO: remove with minimal requirement of Python 3.8


### PR DESCRIPTION
The API wasn't upgraded completely, and the cloud functions throw errors
like this:

        TypeError: pull() takes from 1 to 2 positional arguments but 3
        positional arguments (and 1 keyword-only argument) were given

The API usage needs to be reviewed carefully and all changed calls
updated and tested.

This reverts commit ef70ebdd8f963271626f6b7ea9ae4c3c4f2262ea.