### PR TITLE
README.md: Add KernelCI project logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<img src="https://kernelci.org/image/kernelci-horizontal-color.png"
+     alt="KernelCI project logo"
+     width="40%" />
+
 KCIDB
 =====
 


### PR DESCRIPTION
Add the KernelCI project logo to the top level readme.

Related to kernelci/kernelci-core#868