### PR TITLE
Support specifying schema version to kcidb-upgrade

### DIFF
--- a/kcidb/__init__.py
+++ b/kcidb/__init__.py
@@ -262,11 +262,11 @@ def upgrade_main():
     sys.excepthook = misc.log_and_print_excepthook
     description = 'kcidb-upgrade - Upgrade I/O JSON data to latest schema'
     parser = misc.OutputArgumentParser(description=description)
+    misc.argparse_schema_add_args(parser, "upgrade")
     args = parser.parse_args()
-
     misc.json_dump_stream(
         (
-            io.schema.upgrade(io.schema.validate(data), copy=False)
+            args.schema_version.upgrade(io.schema.validate(data), copy=False)
             for data in misc.json_load_stream_fd(sys.stdin.fileno())
         ),
         sys.stdout, indent=args.indent, seq=args.seq

--- a/kcidb/misc.py
+++ b/kcidb/misc.py
@@ -159,7 +159,7 @@ def non_negative_int(string):
         argparse.ArgumentTypeError: the string wasn't representing a
         non-negative integer.
     """
-    if not re.match("^[0-9]+$", string):
+    if not re.fullmatch("[0-9]+", string):
         raise argparse.ArgumentTypeError(
             f'{repr(string)} is not a positive integer, nor zero'
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ jinja2
 python-dateutil
 cached-property
 jq@git+https://github.com/spbnick/jq.py.git@1.1.2.post1
-kcidb-io@git+https://github.com/kernelci/kcidb-io.git@v3_pre2
+kcidb-io@git+https://github.com/kernelci/kcidb-io.git@v3_pre3

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setuptools.setup(
         "python-dateutil",
         "cached-property",
         "jq@git+https://github.com/spbnick/jq.py.git@1.1.2.post1",
-        "kcidb-io@git+https://github.com/kernelci/kcidb-io.git@v3_pre2",
+        "kcidb-io@git+https://github.com/kernelci/kcidb-io.git@v3_pre3",
     ],
     extras_require=dict(
         dev=[

--- a/test_kcidb.py
+++ b/test_kcidb.py
@@ -221,6 +221,25 @@ class KCIDBMainFunctionsTestCase(kcidb.unittest.TestCase):
                             stdout_re=re.escape(latest_version +
                                                 latest_version))
 
+        self.assertExecutes(latest_version,
+                            "kcidb.upgrade_main", "0",
+                            status=2,
+                            stderr_re=".*Invalid major version number: '0'\n")
+        self.assertExecutes(latest_version,
+                            "kcidb.upgrade_main",
+                            str(kcidb_io.schema.LATEST.major + 1),
+                            status=2,
+                            stderr_re=".*No schema version found for major "
+                            f"number {kcidb_io.schema.LATEST.major + 1}\n")
+
+        self.assertExecutes(latest_version,
+                            "kcidb.upgrade_main", str(major - 1),
+                            status=1, stderr_re=".*ValidationError.*")
+
+        self.assertExecutes(latest_version, "kcidb.upgrade_main",
+                            "--indent=0", str(major),
+                            stdout_re=re.escape(latest_version))
+
     def test_count_main(self):
         """Check kcidb-count works"""
         self.assertExecutes('', "kcidb.count_main")


### PR DESCRIPTION
Support specifying the schema's major version to kcidb-upgrade, so
upgrades could be done to older schema versions.

Fixes #79