### PR TITLE
Restructure docs for KernelCI website

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 KCIDB
 =====
 
-Kcidb is a package for submitting and querying Linux Kernel CI reports,
-and for maintaining the service behind that.
+KCIDB is a package for submitting and querying Linux Kernel CI reports, coming
+from independent CI systems, and for maintaining the service behind that.
 
 See the collected results on
 [our dashboard](https://staging.kernelci.org:3000/).

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ KCIDB
 KCIDB is a package for submitting and querying Linux Kernel CI reports, coming
 from independent CI systems, and for maintaining the service behind that.
 
-See the collected results on
-[our dashboard](https://staging.kernelci.org:3000/).
+See the collected results on [our dashboard](https://kcidb.kernelci.org/).
 Write to [kernelci@groups.io](mailto:kernelci@groups.io) if you want to start
 submitting results from your CI system, or if you want to receive automatic
 notifications of arriving results.

--- a/SUBMISSION_HOWTO.md
+++ b/SUBMISSION_HOWTO.md
@@ -48,6 +48,10 @@ Let's say you picked v8. Run this:
 pip3 install --user 'git+https://git@github.com/kernelci/kcidb.git@v8'
 ```
 
+Then make sure your PATH includes the `~/.local/bin` directory, e.g. with:
+
+    export PATH="$PATH":~/.local/bin
+
 See [README.md](README.md) for alternatives, and if you know your Python, feel
 free to do it your way!
 

--- a/SUBMISSION_HOWTO.md
+++ b/SUBMISSION_HOWTO.md
@@ -78,7 +78,7 @@ $ kcidb-query -d playground_kernelci04
     "checkouts": [],
     "tests": [],
     "version": {
-        "major": 3,
+        "major": 4,
         "minor": 0
     }
 }
@@ -87,7 +87,7 @@ $ kcidb-query -d playground_kernelci04
 and submit an empty report:
 
 ```console
-$ echo '{"version":{"major":3,"minor":0}}' |
+$ echo '{"version":{"major":4,"minor":0}}' |
         kcidb-submit -p kernelci-production -t playground_kernelci_new
 ```
 
@@ -107,7 +107,7 @@ Here's a minimal report, containing no data:
 ```json
 {
     "version": {
-        "major": 3,
+        "major": 4,
         "minor": 0
     }
 }
@@ -155,7 +155,7 @@ checkout with one build and one test:
         }
     ],
     "version": {
-        "major": 3,
+        "major": 4,
         "minor": 0
     }
 }
@@ -200,9 +200,26 @@ shortest possible `git://` URL.
 Example: `"https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git"`
 
 ##### `git_commit_hash`
-The full commit hash of the checked out base code.
+The full commit hash of the checked out base code. Note that until a checkout
+has the `git_commit_hash` property it may not appear in reports or on the
+dashboard.
 
 Example: `"db14560cba31b9fdf8454d097e5cb9e488c621fd"`
+
+##### `patchset_hash`
+The full hash of the patches applied on top of the commit, or an empty string,
+if there were no patches. Note that until a checkout has the `patchset_hash`
+property it may not appear in reports or on the dashboard.
+
+The hash is a sha256 hash over newline-terminated sha256 hashes of each patch,
+in order of application. If your patch file alphabetic order matches the
+application order (which is true for patches generated with `git format-patch`
+or `git send-email`), and you only have the patchset you're hashing in the
+current directory, you can generate the hash with this command:
+
+    sha256sum *.patch | cut -c-64 | sha256sum | cut -c-64
+
+Example: `"a86ef57bf15cd35ba4da4e719e0874c8dd9432bb05d9fb5e45b716d43561d2b8"`
 
 ##### `start_time`
 The time the checkout was started by the CI system. As described by [RFC3339,

--- a/SUBMISSION_HOWTO.md
+++ b/SUBMISSION_HOWTO.md
@@ -27,15 +27,28 @@ like this:
 export GOOGLE_APPLICATION_CREDENTIALS=~/.kcidb-credentials.json
 ```
 
-You will also need to specify some or all of the following to the
-tools/library (using current production parameters from here on):
+We will also need to agree on the "origin" string identifying your system
+among other submitters. We'll use `submitter` in examples below.
+
+Finally you will need to specify some or all of the following to the
+tools/library:
+
+* Google Cloud project: `kernelci-production`
+* Submission queue topic: `playground_kernelci_new`
+* Dataset name: `playground_kernelci04`
+
+The above refers to the special "playground" setup we have, where you can
+freely experiment with your submissions, without worrying about any negative
+effects on the system or other submitters. This setup has a [separate
+dashboard](https://kcidb.kernelci.org/d/home/home?orgId=1&refresh=30m&var-origin=All&var-git_repository_url=All&var-dataset=playground_kernelci04)
+as well. We'll use playground parameters in the examples below.
+
+Once you feel comfortable and ready, we'll add extra permissions for your
+account, and you can start using the production parameters:
 
 * Google Cloud project: `kernelci-production`
 * Submission queue topic: `kernelci_new`
 * Dataset name: `kernelci04`
-
-Finally, we'll need to agree on the "origin" string identifying your system
-among other submitters. We'll use `submitter` in examples below.
 
 2\. Install KCIDB
 -----------------
@@ -59,7 +72,7 @@ To test your installation, authentication, and the parameters you received
 execute an empty query on the database:
 
 ```console
-$ kcidb-query -d kernelci04
+$ kcidb-query -d playground_kernelci04
 {
     "builds": [],
     "checkouts": [],
@@ -75,7 +88,7 @@ and submit an empty report:
 
 ```console
 $ echo '{"version":{"major":3,"minor":0}}' |
-        kcidb-submit -p kernelci-production -t kernelci_new
+        kcidb-submit -p kernelci-production -t playground_kernelci_new
 ```
 
 Both should execute without errors and finish with zero exit status.
@@ -150,7 +163,7 @@ checkout with one build and one test:
 
 If you're curious, you can query the complete objects above with this command:
 
-    kcidb-query -d kernelci04 -t redhat:114353810 --parents
+    kcidb-query -d playground_kernelci04 -t redhat:114353810 --parents
 
 #### Object IDs
 
@@ -314,7 +327,8 @@ As soon as you have your report data pass validation (e.g. with the
 If you're using shell, and e.g. have your data in file `report.json`, pipe it
 to the `kcidb-submit` tool like this:
 
-    kcidb-submit -p kernelci-production -t kernelci_new < report.json
+    kcidb-submit -p kernelci-production \
+                 -t playground_kernelci_new < report.json
 
 If you're using Python 3, and e.g. have variable `report` holding standard
 JSON representation of your report, you can submit it like this:
@@ -323,7 +337,7 @@ JSON representation of your report, you can submit it like this:
 import kcidb
 
 client = kcidb.Client(project_id="kernelci-production",
-                      topic_name="kernelci_new")
+                      topic_name="playground_kernelci_new")
 client.submit(report)
 ```
 
@@ -332,11 +346,11 @@ you should be able to find it in our [dashboard][dashboard], or query using
 the `kcidb-query` command-line tool. For example, if you want to retrieve a
 checkout object you submitted with ID `origin:23223`, execute:
 
-    kcidb-query -d kernelci04 -c origin:23223
+    kcidb-query -d playground_kernelci04 -c origin:23223
 
 If you want to retrieve all its builds and tests as well, execute:
 
-    kcidb-query -d kernelci04 -c origin:23223 --children
+    kcidb-query -d playground_kernelci04 -c origin:23223 --children
 
 See the output of `kcidb-query --help` for usage information, including how to
 retrieve builds, tests, and how to retrieve object parents.

--- a/doc/_index.md
+++ b/doc/_index.md
@@ -1,10 +1,9 @@
-<img src="https://kernelci.org/image/kernelci-horizontal-color.png"
-     alt="KernelCI project logo"
-     width="40%" />
-
-KCIDB
-=====
-
+---
+title: "KCIDB"
+date: 2021-11-18
+draft: false
+description: "KernelCI Database service and tools"
+---
 KCIDB is a package for submitting and querying Linux Kernel CI reports, coming
 from independent CI systems, and for maintaining the service behind that.
 
@@ -12,10 +11,3 @@ See the collected results on [our dashboard](https://kcidb.kernelci.org/).
 Write to [kernelci@groups.io](mailto:kernelci@groups.io) if you want to start
 submitting results from your CI system, or if you want to receive automatic
 notifications of arriving results.
-
-See our guides for more information:
-
-[Installation](doc/INSTALLATION.md)
-[Submitter guide](doc/SUBMITTER_GUIDE.md)
-[Developer guide](doc/DEVELOPER_GUIDE.md)
-[Administrator guide](doc/ADMINISTRATOR_GUIDE.md)

--- a/doc/administrator_guide.md
+++ b/doc/administrator_guide.md
@@ -1,6 +1,10 @@
-Administrator guide
-===================
-
+---
+title: "Administrator guide"
+date: 2021-11-18
+draft: false
+wieght: 40
+description: "Deploying, maintaining, and upgrading a KCIDB service installation"
+---
 Kcidb infrastructure is mostly based on Google Cloud services at the moment:
 
     === Hosts ===  ======================= Google Cloud Project ========================

--- a/doc/developer_guide.md
+++ b/doc/developer_guide.md
@@ -1,0 +1,33 @@
+---
+title: "Developer guide"
+date: 2021-11-18
+draft: false
+weight: 30
+description: "Setting up for KCIDB development"
+---
+Hacking
+-------
+
+If you want to hack on the source code, install the package in the editable
+mode with the `-e/--editable` option, and with "dev" extra included. E.g.:
+
+    pip3 install --user --editable '.[dev]'
+
+The latter installs kcidb executables which use the modules from the source
+directory, and changes to them will be reflected immediately without the need
+to reinstall. It also installs extra development tools, such as `flake8` and
+`pylint`.
+
+Then make sure your PATH includes the `~/.local/bin` directory, e.g. with:
+
+    export PATH="$PATH":~/.local/bin
+
+Releasing
+---------
+
+Before releasing make sure the documentation files are up to date.
+
+To make a release tag the release commit with `v<NUMBER>`, where `<NUMBER>` is
+the next release number, e.g. `v3`. The very next commit after the tag should
+update the version number in `setup.py` to be the next one. I.e. continuing
+the above example, it should be `4`.

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -1,0 +1,40 @@
+---
+title: "Installation"
+date: 2021-11-18
+draft: false
+weight: 10
+description: "How to install the KCIDB package"
+---
+KCIDB requires Python v3.6 or later.
+
+To install the package for the current user, run this command:
+
+    pip3 install --user <SOURCE>
+
+Where `<SOURCE>` is the location of the package source, e.g. a git repo:
+
+    pip3 install --user git+https://github.com/kernelci/kcidb.git
+
+a (release) tag in a git repo:
+
+    pip3 install --user git+https://github.com/kernelci/kcidb.git@v9
+
+or a directory path:
+
+    pip3 install --user .
+
+In any case, make sure your PATH includes the `~/.local/bin` directory, e.g.
+with:
+
+    export PATH="$PATH":~/.local/bin
+
+Before you execute any of the tools make sure you have the path to your Google
+Cloud credentials stored in the `GOOGLE_APPLICATION_CREDENTIALS` variable.
+E.g.:
+
+    export GOOGLE_APPLICATION_CREDENTIALS=~/.credentials.json
+
+If you're representing a submitting CI system accessing the KCIDB service, you
+will get your credentials from us. Otherwise you will need to create a service
+account in your Google Cloud project, and download its key file to act as the
+credentials.

--- a/doc/submitter_guide.md
+++ b/doc/submitter_guide.md
@@ -1,7 +1,11 @@
-How to submit reports with KCIDB
-================================
-
-Here's what you need to do.
+---
+title: "Submitter guide"
+date: 2021-11-18
+draft: false
+weight: 20
+description: "How to submit build and test reports with KCIDB"
+---
+Here's what you need to do to submit your reports.
 
 1. Get submission credentials and parameters.
 2. Install KCIDB.
@@ -65,8 +69,8 @@ Then make sure your PATH includes the `~/.local/bin` directory, e.g. with:
 
     export PATH="$PATH":~/.local/bin
 
-See [README.md](README.md) for alternatives, and if you know your Python, feel
-free to do it your way!
+See [Installation](../installation) for alternatives, and if you know your
+Python, feel free to do it your way!
 
 To test your installation, authentication, and the parameters you received
 execute an empty query on the database:


### PR DESCRIPTION
Reorganize the documentation to enable its inclusion into the
Hugo-generated docs on the KernelCI website.

Extract the installation and the developer guide sections into their own
files. Put all the documentation files into the "doc" directory, and
adjust whatever links are there to work under Hugo (but unfortunately
not with GitHub rendering, or with manual following). Add front matter
to every documentation file, and adjust headers to work with headers
added by Hugo.

Add a bunch of updates and improvements before doing the above.