### PR TITLE
monitor: Do not render messages repeatedly

### DIFF
--- a/kcidb/monitor/__init__.py
+++ b/kcidb/monitor/__init__.py
@@ -48,7 +48,6 @@ def match(oo_data, match_map=None):
                 for message in function(obj) or []:
                     assert isinstance(message, output.NotificationMessage)
                     notifications.append(
-                        output.Notification(obj_type_name, obj,
-                                            subscription, message)
+                        output.Notification(obj, subscription, message)
                     )
     return notifications

--- a/kcidb/monitor/output.py
+++ b/kcidb/monitor/output.py
@@ -120,13 +120,11 @@ class Notification:
         return base64.b64decode(id_part, altchars=b'+-',
                                 validate=True).decode()
 
-    def __init__(self, obj_type_name, obj, subscription, message):
+    def __init__(self, obj, subscription, message):
         """
         Initialize a notification.
 
         Args:
-            obj_type_name:  Name of the object type (e.g. "revision") to
-                            which the object notified about belongs.
             obj:            Object-oriented representation of the object
                             being notified about (an instance of
                             kcidb.oo.Object).
@@ -139,20 +137,17 @@ class Notification:
             message:        Notification message. An instance of
                             NotificationMessage.
         """
-        assert isinstance(obj_type_name, str)
-        assert obj_type_name
         assert isinstance(obj, kcidb.oo.Object)
         assert isinstance(subscription, str)
         assert SUBSCRIPTION_RE.fullmatch(subscription)
         assert len(subscription.encode()) <= 64
         assert isinstance(message, NotificationMessage)
 
-        self.obj_type_name = obj_type_name
         self.obj = obj
         self.subscription = subscription
         self.message = message
         id = self.subscription + ":" + \
-            self.obj_type_name + ":" + \
+            self.obj.get_type().name + ":" + \
             Notification._to_id_part(repr(obj.get_id())) + ":" + \
             Notification._to_id_part(message.id)
         assert is_valid_firestore_id(id)

--- a/kcidb/monitor/test_output.py
+++ b/kcidb/monitor/test_output.py
@@ -61,8 +61,7 @@ class NotificationTestCase(unittest.TestCase):
             '{% include "revision_description.txt.j2" %}',
             id="id"
         )
-        notification = Notification("revision",
-                                    oo_data["revision"][0],
+        notification = Notification(oo_data["revision"][0],
                                     "subscription",
                                     notification_message)
         self.assertEqual(notification.id,

--- a/kcidb/test_monitor.py
+++ b/kcidb/test_monitor.py
@@ -190,7 +190,7 @@ class MatchTestCase(unittest.TestCase):
         notifications = monitor.match(oo_data)
         self.assertEqual(len(notifications), 4)
         for notification in notifications:
-            obj_type_name = notification.obj_type_name
+            obj_type_name = notification.obj.get_type().name
             self.assertIsInstance(notification, monitor.output.Notification)
             message = notification.render()
             self.assertIsNone(message['From'])


### PR DESCRIPTION
Do not render the notification message before we know it wasn't sent already. I.e. first create the doc atomically, then render the message and store it there.

This avoids the overhead of rendering messages for notifications which were already sent. E.g. for a revision subscription, which sent its notification on the arrival of its first failed test, but would trigger on every next test arriving, because it already has a failed one.