### PR TITLE
Revert "monitor: Do not render messages repeatedly"

### DIFF
--- a/kcidb/monitor/spool/__init__.py
+++ b/kcidb/monitor/spool/__init__.py
@@ -108,34 +108,17 @@ class Client:
         if timestamp is None:
             timestamp = datetime.datetime.now(datetime.timezone.utc)
 
-        doc = self._get_doc(notification.id)
         try:
-            # Try to create an empty, permanently-picked document to avoid
-            # rendering the message unnecessarily, in case it was already
-            # spooled.
-            doc.create(dict(
+            self._get_doc(notification.id).create(dict(
                 created_at=timestamp,
-                # Marked picked forever
-                picked_until=datetime.datetime.max,
-            ))
-        except Conflict:
-            # The document already existed, abort
-            return False
-
-        # The document didn't exist, add our message, and mark "unpicked"
-        try:
-            doc.update(field_updates=dict(
                 # Set to a definitely timed-out time, free for picking
                 picked_until=datetime.datetime.min,
                 message=notification.render().as_string(
                     policy=email.policy.SMTPUTF8
                 ),
             ))
-        except Exception:
-            # Try to delete the document if failed for whatever reason
-            doc.delete()
-            raise
-
+        except Conflict:
+            return False
         return True
 
     def pick(self, id, timestamp=None, timeout=None):


### PR DESCRIPTION
Switch back to creating the message in the spool in one go, since our
message-sending Cloud Function is triggered off new objects being
created, and risks getting triggered off an incomplete object, if it's
created in two steps.

We would still need to avoid rendering messages repeatedly, but with the
current (very dumb) ORM caching it's not so critical.

This reverts commit b1d916642876d5d16869f6b41219f0158a237652.