### PR TITLE
cloud: Double memory for kcidb_spool_notifications

### DIFF
--- a/cloud
+++ b/cloud
@@ -616,7 +616,7 @@ function cloud_functions_deploy() {
                           --env-vars-file "$env_yaml" \
                           --runtime python37 \
                           --trigger-topic "${updated_topic}" \
-                          --memory 1024MB \
+                          --memory 2048MB \
                           --timeout 540
 
     cloud_function_deploy "$project" "${prefix}load_queue" \


### PR DESCRIPTION
Double the memory allocated for the notification-spooling Cloud
Function, since it's been running out of memory recently.