### PR TITLE
Record currently-used schema version in kcidb.io module

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -14,7 +14,7 @@ extension-pkg-whitelist=jq
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=duplicate-code,fixme,too-few-public-methods,redefined-builtin
+disable=duplicate-code,fixme,too-few-public-methods,redefined-builtin,consider-using-from-import
 
 [REPORTS]
 # Activate the evaluation score.

--- a/kcidb/__init__.py
+++ b/kcidb/__init__.py
@@ -9,11 +9,6 @@ from kcidb.misc import LIGHT_ASSERTS
 from kcidb import db, mq, orm, oo, monitor, tests, unittest, misc # noqa
 
 
-# pylint: disable=invalid-name
-# TODO Remove once users switched to kcidb_io.schema
-# Compatibility alias
-io_schema = io.schema
-
 # Module's logger
 LOGGER = logging.getLogger(__name__)
 

--- a/kcidb/__init__.py
+++ b/kcidb/__init__.py
@@ -3,10 +3,9 @@
 import sys
 import email
 import logging
-import kcidb_io as io
 from kcidb.misc import LIGHT_ASSERTS
 # Silence flake8 "imported but unused" warning
-from kcidb import db, mq, orm, oo, monitor, tests, unittest, misc # noqa
+from kcidb import io, db, mq, orm, oo, monitor, tests, unittest, misc # noqa
 
 
 # Module's logger

--- a/kcidb/db/__init__.py
+++ b/kcidb/db/__init__.py
@@ -3,7 +3,7 @@
 import sys
 import logging
 import argparse
-import kcidb_io as io
+import kcidb.io as io
 import kcidb.orm
 import kcidb.misc
 from kcidb.misc import LIGHT_ASSERTS

--- a/kcidb/db/bigquery/__init__.py
+++ b/kcidb/db/bigquery/__init__.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from google.cloud import bigquery
 from google.api_core.exceptions import BadRequest as GoogleBadRequest
 from google.api_core.exceptions import NotFound as GoogleNotFound
-import kcidb_io as io
+import kcidb.io as io
 import kcidb.orm
 from kcidb.db.bigquery import schema
 from kcidb.misc import LIGHT_ASSERTS

--- a/kcidb/db/json/__init__.py
+++ b/kcidb/db/json/__init__.py
@@ -2,7 +2,7 @@
 
 import sys
 import textwrap
-import kcidb_io as io
+import kcidb.io as io
 import kcidb.misc
 from kcidb.db.sqlite import Driver as SQLiteDriver
 

--- a/kcidb/db/misc.py
+++ b/kcidb/db/misc.py
@@ -1,7 +1,7 @@
 """Kernel CI reporting database - misc definitions"""
 
 from abc import ABC, abstractmethod
-import kcidb_io as io
+import kcidb.io as io
 import kcidb.orm
 from kcidb.misc import LIGHT_ASSERTS
 

--- a/kcidb/db/null/__init__.py
+++ b/kcidb/db/null/__init__.py
@@ -2,7 +2,7 @@
 
 import textwrap
 import datetime
-import kcidb_io as io
+import kcidb.io as io
 from kcidb.db.misc import Driver as AbstractDriver
 
 

--- a/kcidb/db/sqlite/__init__.py
+++ b/kcidb/db/sqlite/__init__.py
@@ -6,7 +6,7 @@ import textwrap
 import sqlite3
 from functools import reduce
 import datetime
-import kcidb_io as io
+import kcidb.io as io
 import kcidb.orm
 from kcidb.misc import LIGHT_ASSERTS
 from kcidb.db.sqlite import schema

--- a/kcidb/io.py
+++ b/kcidb/io.py
@@ -1,0 +1,6 @@
+"""KCIDB package-specific I/O definitions"""
+
+# Inherit all public definitions from kcidb_io package
+# We know what we're doing, flake8 and
+# pylint: disable=wildcard-import,unused-wildcard-import
+from kcidb_io import *  # noqa: F403

--- a/kcidb/io.py
+++ b/kcidb/io.py
@@ -4,3 +4,6 @@
 # We know what we're doing, flake8 and
 # pylint: disable=wildcard-import,unused-wildcard-import
 from kcidb_io import *  # noqa: F403
+
+# The I/O schema version used by KCIDB
+SCHEMA = schema.V4  # noqa: F405

--- a/kcidb/misc.py
+++ b/kcidb/misc.py
@@ -14,7 +14,7 @@ except ImportError:  # Python 3.6
     import importlib_metadata as metadata
 from google.cloud import secretmanager
 import jq
-import kcidb_io as io
+import kcidb.io as io
 
 # Module's logger
 LOGGER = logging.getLogger(__name__)

--- a/kcidb/monitor/test_output.py
+++ b/kcidb/monitor/test_output.py
@@ -2,7 +2,7 @@
 
 import email
 import unittest
-from kcidb_io import schema
+from kcidb.io import schema
 from kcidb import orm, db, oo
 from kcidb.monitor.output import NotificationMessage, Notification
 

--- a/kcidb/mq/__init__.py
+++ b/kcidb/mq/__init__.py
@@ -8,7 +8,7 @@ import argparse
 from abc import ABC, abstractmethod
 from google.cloud import pubsub
 from google.api_core.exceptions import DeadlineExceeded
-import kcidb_io as io
+import kcidb.io as io
 import kcidb.orm
 from kcidb import misc
 from kcidb.misc import LIGHT_ASSERTS

--- a/kcidb/orm/__init__.py
+++ b/kcidb/orm/__init__.py
@@ -9,7 +9,7 @@ import logging
 import argparse
 from abc import ABC, abstractmethod
 import jsonschema
-import kcidb_io as io
+import kcidb.io as io
 import kcidb.misc
 from kcidb.misc import LIGHT_ASSERTS
 

--- a/kcidb/test_db.py
+++ b/kcidb/test_db.py
@@ -4,7 +4,6 @@ import re
 import textwrap
 import json
 from unittest.mock import Mock, patch
-import kcidb_io
 import kcidb
 
 
@@ -47,7 +46,7 @@ class KCIDBDBMainFunctionsTestCase(kcidb.unittest.TestCase):
 
     def test_dump_main(self):
         """Check kcidb-db-dump works"""
-        empty = kcidb_io.new()
+        empty = kcidb.io.new()
         argv = ["kcidb.db.dump_main", "-d", "bigquery:project.dataset",
                 "--indent=0"]
 
@@ -97,7 +96,7 @@ class KCIDBDBMainFunctionsTestCase(kcidb.unittest.TestCase):
             "--parents", "--children", "--objects-per-report", "10",
             "--indent=0",
         ]
-        empty = kcidb_io.new()
+        empty = kcidb.io.new()
         driver_source = textwrap.dedent(f"""
             from unittest.mock import patch, Mock
             client = Mock()
@@ -141,7 +140,7 @@ class KCIDBDBMainFunctionsTestCase(kcidb.unittest.TestCase):
         self.assertExecutes('{}', *argv, driver_source=driver_source,
                             status=1, stderr_re=".*ValidationError.*")
 
-        empty = kcidb_io.new()
+        empty = kcidb.io.new()
 
         driver_source = textwrap.dedent(f"""
             from unittest.mock import patch, Mock
@@ -177,7 +176,7 @@ class KCIDBDBClient(kcidb.unittest.TestCase):
 
     # I/O data containing all possible fields
     COMPREHENSIVE_IO_DATA = {
-        **kcidb_io.new(),
+        **kcidb.io.new(),
         "checkouts": [
             dict(
                 id="origin:1",

--- a/kcidb/test_monitor.py
+++ b/kcidb/test_monitor.py
@@ -1,7 +1,7 @@
 """kcdib.monitor module tests"""
 
 import unittest
-from kcidb_io import schema
+from kcidb.io import schema
 from kcidb import orm, db, oo, monitor
 
 # Disable long line checking for JSON data

--- a/kcidb/test_mq.py
+++ b/kcidb/test_mq.py
@@ -3,7 +3,6 @@
 import re
 import textwrap
 import json
-import kcidb_io
 import kcidb
 
 
@@ -48,7 +47,7 @@ class KCIDBMQMainFunctionsTestCase(kcidb.unittest.TestCase):
         """Check kcidb-mq-io-publisher publish works"""
         argv = ["kcidb.mq.io_publisher_main",
                 "-p", "project", "-t", "topic", "publish"]
-        empty = kcidb_io.new()
+        empty = kcidb.io.new()
 
         driver_source = textwrap.dedent("""
             from unittest.mock import patch, Mock
@@ -147,7 +146,7 @@ class KCIDBMQMainFunctionsTestCase(kcidb.unittest.TestCase):
         argv = ["kcidb.mq.io_subscriber_main",
                 "-p", "project", "-t", "topic", "-s", "subscription",
                 "pull", "--timeout", "123", "--indent=0"]
-        empty = kcidb_io.new()
+        empty = kcidb.io.new()
         driver_source = textwrap.dedent(f"""
             from unittest.mock import patch, Mock
             subscriber = Mock()

--- a/kcidb/test_orm.py
+++ b/kcidb/test_orm.py
@@ -3,7 +3,6 @@
 # Over 1000 lines, pylint: disable=too-many-lines
 
 from jinja2 import Template
-import kcidb_io
 import kcidb
 
 
@@ -331,7 +330,7 @@ class KCIDBORMPatternTestCase(kcidb.unittest.TestCase):
         """
         Check Pattern.from_io() works correctly.
         """
-        io_data = kcidb_io.new()
+        io_data = kcidb.io.new()
         self.assertEqual(from_io(io_data), set())
 
         io_data = {
@@ -341,7 +340,7 @@ class KCIDBORMPatternTestCase(kcidb.unittest.TestCase):
             ],
             "tests": [
             ],
-            **kcidb_io.new()
+            **kcidb.io.new()
         }
         self.assertEqual(from_io(io_data), set())
 
@@ -355,7 +354,7 @@ class KCIDBORMPatternTestCase(kcidb.unittest.TestCase):
                     "origin": "origin",
                 },
             ],
-            **kcidb_io.new()
+            **kcidb.io.new()
         }
         self.assertEqual(from_io(io_data), {
             pattern(None, True, "checkout", {("origin:1",)})
@@ -385,7 +384,7 @@ class KCIDBORMPatternTestCase(kcidb.unittest.TestCase):
                     "origin": "origin",
                 },
             ],
-            **kcidb_io.new()
+            **kcidb.io.new()
         }
         self.assertEqual(from_io(io_data), {
             pattern(
@@ -402,7 +401,7 @@ class KCIDBORMPatternTestCase(kcidb.unittest.TestCase):
                     "origin": "origin",
                 },
             ],
-            **kcidb_io.new()
+            **kcidb.io.new()
         }
         self.assertEqual(from_io(io_data), {
             pattern(None, True, "build", {("origin:2",)})
@@ -416,7 +415,7 @@ class KCIDBORMPatternTestCase(kcidb.unittest.TestCase):
                     "origin": "origin",
                 },
             ],
-            **kcidb_io.new()
+            **kcidb.io.new()
         }
         self.assertEqual(from_io(io_data), {
             pattern(None, True, "test", {("origin:3",)})
@@ -446,7 +445,7 @@ class KCIDBORMPatternTestCase(kcidb.unittest.TestCase):
                     "origin": "origin",
                 },
             ],
-            **kcidb_io.new()
+            **kcidb.io.new()
         }
         self.assertEqual(from_io(io_data), {
             pattern(None, True, "checkout", {("origin:1",)}),

--- a/main.py
+++ b/main.py
@@ -6,7 +6,6 @@ import base64
 import datetime
 import logging
 import smtplib
-import kcidb_io
 import kcidb
 
 
@@ -120,7 +119,7 @@ def kcidb_load_queue_msgs(subscriber, msg_max, obj_max, timeout_sec):
 
         # Add messages up to obj_max, except the first one
         for index, msg in enumerate(pull_msgs):
-            msg_obj_num = kcidb_io.count(msg[1])
+            msg_obj_num = kcidb.io.count(msg[1])
             obj_num += msg_obj_num
             if msgs and obj_num > obj_max:
                 LOGGER.debug("Message #%u crossed %u-object boundary "
@@ -171,11 +170,11 @@ def kcidb_load_queue(event, context):
 
     # Create merged data referencing the pulled pieces
     LOGGER.debug("Merging %u messages...", len(msgs))
-    data = kcidb_io.merge(kcidb_io.new(), (msg[1] for msg in msgs),
+    data = kcidb.io.merge(kcidb.io.new(), (msg[1] for msg in msgs),
                           copy_target=False, copy_sources=False)
     LOGGER.info("Merged %u messages", len(msgs))
     # Load the merged data into the database
-    obj_num = kcidb_io.count(data)
+    obj_num = kcidb.io.count(data)
     LOGGER.debug("Loading %u objects...", obj_num)
     DB_CLIENT.load(data)
     LOGGER.info("Loaded %u objects", obj_num)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ jinja2
 python-dateutil
 cached-property
 jq@git+https://github.com/kernelci/jq.py.git@1.2.1.post1
-kcidb-io@git+https://github.com/kernelci/kcidb-io.git@v3
+kcidb-io@git+https://github.com/kernelci/kcidb-io.git@v4_pre1

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setuptools.setup(
         "python-dateutil",
         "cached-property",
         "jq@git+https://github.com/kernelci/jq.py.git@1.2.1.post1",
-        "kcidb-io@git+https://github.com/kernelci/kcidb-io.git@v3",
+        "kcidb-io@git+https://github.com/kernelci/kcidb-io.git@v4_pre1",
     ],
     extras_require=dict(
         dev=[

--- a/test_kcidb.py
+++ b/test_kcidb.py
@@ -3,7 +3,6 @@
 import re
 import json
 import textwrap
-import kcidb_io
 import kcidb
 
 
@@ -12,7 +11,7 @@ class LightAssertsTestCase(kcidb.unittest.TestCase):
 
     def test_light_asserts_are_disabled(self):
         """Check light asserts are disabled"""
-        self.assertFalse(kcidb_io.misc.LIGHT_ASSERTS,
+        self.assertFalse(kcidb.io.misc.LIGHT_ASSERTS,
                          "Tests must run with KCIDB_IO_HEAVY_ASSERTS "
                          "environment variable set to a non-empty string")
         self.assertFalse(kcidb.misc.LIGHT_ASSERTS,
@@ -55,7 +54,7 @@ class KCIDBMainFunctionsTestCase(kcidb.unittest.TestCase):
         self.assertExecutes('{}', *argv, driver_source=driver_source,
                             status=1, stderr_re=".*ValidationError.*")
 
-        empty = kcidb_io.new()
+        empty = kcidb.io.new()
 
         driver_source = textwrap.dedent(f"""
             from unittest.mock import patch, Mock
@@ -114,7 +113,7 @@ class KCIDBMainFunctionsTestCase(kcidb.unittest.TestCase):
             "--parents", "--children", "--objects-per-report", "10",
             "--indent=0",
         ]
-        empty = kcidb_io.new()
+        empty = kcidb.io.new()
         driver_source = textwrap.dedent(f"""
             from unittest.mock import patch, Mock
             client = Mock()
@@ -149,12 +148,12 @@ class KCIDBMainFunctionsTestCase(kcidb.unittest.TestCase):
         """Check kcidb-schema works"""
         self.assertExecutes(
                 "", "kcidb.schema_main",
-                stdout_re=f'.*"const": {kcidb_io.schema.LATEST.major},.*'
+                stdout_re=f'.*"const": {kcidb.io.schema.LATEST.major},.*'
         )
         self.assertExecutes(
                 "", "kcidb.schema_main",
-                str(kcidb_io.schema.LATEST.major - 1),
-                stdout_re=f'.*"const": {kcidb_io.schema.LATEST.major - 1},.*'
+                str(kcidb.io.schema.LATEST.major - 1),
+                stdout_re=f'.*"const": {kcidb.io.schema.LATEST.major - 1},.*'
         )
         self.assertExecutes("",
                             "kcidb.schema_main", "0",
@@ -162,10 +161,10 @@ class KCIDBMainFunctionsTestCase(kcidb.unittest.TestCase):
                             stderr_re=".*Invalid major version number: '0'\n")
         self.assertExecutes('{"version":{"major":4,"minor":0}}',
                             "kcidb.schema_main",
-                            str(kcidb_io.schema.LATEST.major + 1),
+                            str(kcidb.io.schema.LATEST.major + 1),
                             status=2,
                             stderr_re=".*No schema version found for major "
-                            f"number {kcidb_io.schema.LATEST.major + 1}\n")
+                            f"number {kcidb.io.schema.LATEST.major + 1}\n")
 
     def test_validate_main(self):
         """Check kcidb-validate works"""
@@ -192,10 +191,10 @@ class KCIDBMainFunctionsTestCase(kcidb.unittest.TestCase):
                             stderr_re=".*Invalid major version number: '0'\n")
         self.assertExecutes('{"version":{"major":4,"minor":0}}',
                             "kcidb.validate_main",
-                            str(kcidb_io.schema.LATEST.major + 1),
+                            str(kcidb.io.schema.LATEST.major + 1),
                             status=2,
                             stderr_re=".*No schema version found for major "
-                            f"number {kcidb_io.schema.LATEST.major + 1}\n")
+                            f"number {kcidb.io.schema.LATEST.major + 1}\n")
         self.assertExecutes('{', "kcidb.validate_main",
                             status=1, stderr_re=".*JSONParseError.*")
         self.assertExecutes('{}', "kcidb.validate_main",
@@ -210,8 +209,8 @@ class KCIDBMainFunctionsTestCase(kcidb.unittest.TestCase):
 
     def test_upgrade_main(self):
         """Check kcidb-upgrade works"""
-        major = kcidb_io.schema.LATEST.major
-        minor = kcidb_io.schema.LATEST.minor
+        major = kcidb.io.schema.LATEST.major
+        minor = kcidb.io.schema.LATEST.minor
 
         prev_version = \
             json.dumps(dict(version=dict(major=major - 1, minor=minor))) + "\n"
@@ -242,10 +241,10 @@ class KCIDBMainFunctionsTestCase(kcidb.unittest.TestCase):
                             stderr_re=".*Invalid major version number: '0'\n")
         self.assertExecutes(latest_version,
                             "kcidb.upgrade_main",
-                            str(kcidb_io.schema.LATEST.major + 1),
+                            str(kcidb.io.schema.LATEST.major + 1),
                             status=2,
                             stderr_re=".*No schema version found for major "
-                            f"number {kcidb_io.schema.LATEST.major + 1}\n")
+                            f"number {kcidb.io.schema.LATEST.major + 1}\n")
 
         self.assertExecutes(latest_version,
                             "kcidb.upgrade_main", str(major - 1),


### PR DESCRIPTION
Record the currently-used schema version in the new `kcidb.io` module.

Concerns #155
Provides support to #289, which can now use `kcidb.io.SCHEMA` to refer to the object for the currently-used schema version.

@mharyam, please review.