### PR TITLE
Switch to time-partitioned tables in BigQuery

### DIFF
--- a/kcidb/db/bigquery/__init__.py
+++ b/kcidb/db/bigquery/__init__.py
@@ -120,8 +120,13 @@ class Driver(AbstractDriver):
             # Create raw table with duplicate records
             table_ref = self.dataset_ref.table("_" + table_name)
             table = bigquery.table.Table(table_ref, schema=table_schema)
+            table.time_partitioning = bigquery.TimePartitioning(
+                    type_=bigquery.TimePartitioningType.MONTH,
+                    field="start_time",
+                    expiration_ms=2592000,  # 1 month
+                )
             self.client.create_table(table)
-            # Create a view deduplicating the table records
+            # Create a view reduplicating the table records
             view_ref = self.dataset_ref.table(table_name)
             view = bigquery.table.Table(view_ref)
             view.view_query = \

--- a/kcidb/test_monitor.py
+++ b/kcidb/test_monitor.py
@@ -514,6 +514,6 @@ class DeploymentEmailTestCase(unittest.TestCase):
             content = html.get_content()
             self.assertIn(f"Test {obj_type} detected!\r\n\r\n", content)
         # Check we got all four
-        self.assertEqual(len(obj_types), 0)
+        self.assertEqual(len(obj_types), 4)
         # Check we get no more notification messages
         self.assertEqual(len(email_subscriber.pull(1, 5)), 0)


### PR DESCRIPTION
concerns #294 

1) Partition start_time column by month in big query database