### PR TITLE
cloud: Bump load_queue function memory again

### DIFF
--- a/cloud
+++ b/cloud
@@ -1352,7 +1352,7 @@ function cloud_functions_deploy() {
                           --env-vars-file "$env_yaml" \
                           --runtime python37 \
                           --trigger-topic "${load_queue_trigger_topic}" \
-                          --memory 512MB \
+                          --memory 1024MB \
                           --timeout 540
     # Remove the environment YAML
     rm "$env_yaml"


### PR DESCRIPTION
Bump the kcidb_load_queue() function memory limit again, to 1GB, to try
to deal with it getting killed due to memory use.

If this doesn't help we'll have to actively look for memory spikes,
likely in psycopg2 use.