### PR TITLE
Actions: Force older Ubuntu with Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,14 @@ env:
 jobs:
   check_python:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
+        runs-on: [ubuntu-latest]
+        include:
+          - python-version: "3.6"
+            runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Force using an older Ubuntu release which still supports Python 3.6 to keep testing it.