### PR TITLE
submit: Clarify that we are submitting a JSON object

### DIFF
--- a/kcidb/__init__.py
+++ b/kcidb/__init__.py
@@ -64,8 +64,10 @@ class Client:
         Submit reports.
 
         Args:
-            data:   The JSON report data to submit.
-                    Must adhere to the current version of I/O schema.
+            data:   A JSON object with the report data to submit.
+                    Must adhere to the current version of I/O schema,
+                    note that this function will not validate the
+                    submitted data.
 
         Returns:
             Submission ID string.


### PR DESCRIPTION
The documentation for submit() says that it needs to be passed JSON, making a bit ambiguous if this means a Python JSON object or the rendered JSON.  Explicitly say that the former is required.