### PR TITLE
Switch to new draft7 format checker of jsonschema

### DIFF
--- a/kcidb/orm/__init__.py
+++ b/kcidb/orm/__init__.py
@@ -110,8 +110,15 @@ class Type:
             `jsonschema.exceptions.ValidationError`, if the data did not
             adhere to this type's JSON schema.
         """
+        try:
+            format_checker = jsonschema.Draft7Validator.FORMAT_CHECKER
+        except AttributeError:
+            # Nevermind, pylint: disable=fixme
+            # TODO Remove once we stop supporting Python 3.6
+            format_checker = jsonschema.draft7_format_checker
+
         jsonschema.validate(instance=data, schema=self.json_schema,
-                            format_checker=jsonschema.draft7_format_checker)
+                            format_checker=format_checker)
         return data
 
     def is_valid(self, data):
@@ -273,8 +280,15 @@ class Schema:
             `jsonschema.exceptions.ValidationError`, if the data did not
             match the schema.
         """
+        try:
+            format_checker = jsonschema.Draft7Validator.FORMAT_CHECKER
+        except AttributeError:
+            # Nevermind, pylint: disable=fixme
+            # TODO Remove once we stop supporting Python 3.6
+            format_checker = jsonschema.draft7_format_checker
+
         jsonschema.validate(instance=data, schema=self.json_schema,
-                            format_checker=jsonschema.draft7_format_checker)
+                            format_checker=format_checker)
         return data
 
     def is_valid(self, data):

--- a/kcidb/tests/schema.py
+++ b/kcidb/tests/schema.py
@@ -56,6 +56,13 @@ def validate(catalog):
         `jsonschema.exceptions.ValidationError` if the catalog
             is invalid
     """
+    try:
+        format_checker = jsonschema.Draft7Validator.FORMAT_CHECKER
+    except AttributeError:
+        # Nevermind, pylint: disable=fixme
+        # TODO Remove once we stop supporting Python 3.6
+        format_checker = jsonschema.draft7_format_checker
+
     jsonschema.validate(instance=catalog, schema=JSON,
-                        format_checker=jsonschema.draft7_format_checker)
+                        format_checker=format_checker)
     return catalog


### PR DESCRIPTION
Switch to using the new format checker object of the jsonschema package. This fixes the deprecation warning.