### PR TITLE
main: Limit number of objects per pattern

### DIFF
--- a/cloud
+++ b/cloud
@@ -1361,6 +1361,7 @@ function cloud_functions_deploy() {
                           --runtime python37 \
                           --trigger-topic "${pick_notifications_trigger_topic}" \
                           --memory 256MB \
+                          --max-instances=1 \
                           --timeout 540
     cloud_function_deploy "$project" "${prefix}send_notification" \
                           "$source" \
@@ -1371,6 +1372,7 @@ function cloud_functions_deploy() {
                           --trigger-resource "${trigger_resource}" \
                           --memory 256MB \
                           --retry \
+                          --max-instances=1 \
                           --timeout 540
 
     cloud_function_deploy "$project" "${prefix}spool_notifications" \
@@ -1380,6 +1382,7 @@ function cloud_functions_deploy() {
                           --runtime python37 \
                           --trigger-topic "${updated_topic}" \
                           --memory 2048MB \
+                          --max-instances=10 \
                           --timeout 540
 
     cloud_function_deploy "$project" "${prefix}load_queue" \
@@ -1389,6 +1392,7 @@ function cloud_functions_deploy() {
                           --runtime python37 \
                           --trigger-topic "${load_queue_trigger_topic}" \
                           --memory 1024MB \
+                          --max-instances=1 \
                           --timeout 540
     # Remove the environment YAML file
     rm "$env_yaml_file"

--- a/cloud
+++ b/cloud
@@ -1263,9 +1263,9 @@ function cloud_functions_env() {
                           -- "$@")"
     eval "$params"
     if "$heavy_asserts"; then
-        declare -r updated_queue_pattern_max="256"
+        declare -r updated_queue_obj_max="256"
     else
-        declare -r updated_queue_pattern_max="2048"
+        declare -r updated_queue_obj_max="2048"
     fi
     declare -A env=(
         [KCIDB_LOG_LEVEL]="$log_level"
@@ -1280,7 +1280,7 @@ function cloud_functions_env() {
         [KCIDB_CLEAN_TEST_DATABASES]="$clean_test_databases"
         [KCIDB_EMPTY_TEST_DATABASES]="$empty_test_databases"
         [KCIDB_UPDATED_QUEUE_TOPIC]="$updated_topic"
-        [KCIDB_UPDATED_QUEUE_PATTERN_MAX]="$updated_queue_pattern_max"
+        [KCIDB_UPDATED_QUEUE_OBJ_MAX]="$updated_queue_obj_max"
         [KCIDB_SELECTED_SUBSCRIPTIONS]=""
         [KCIDB_SPOOL_COLLECTION_PATH]="$spool_collection_path"
         [KCIDB_SMTP_HOST]="smtp.gmail.com"

--- a/kcidb/db/postgresql/v04_00.py
+++ b/kcidb/db/postgresql/v04_00.py
@@ -464,7 +464,7 @@ class Schema(AbstractSchema):
                 )
             """))
             cursor.execute(textwrap.dedent("""\
-                CREATE AGGREGATE last(anyelement) (
+                CREATE OR REPLACE AGGREGATE last(anyelement) (
                     SFUNC = last_agg,
                     STYPE = anyelement,
                     PARALLEL = safe

--- a/kcidb/misc.py
+++ b/kcidb/misc.py
@@ -490,13 +490,18 @@ def merge_dicts(*args, **kwargs):
 
 def isliced(iterable, size):
     """
-    Create a generator yielding tuples of specified maximum number
-    of elements from an iterable.
+    Create a generator yielding iterables of specified maximum number of
+    elements from an iterable.
 
     Args:
         iterable:   The iterable to return elements from.
-        size:       Maximum number of elements in each tuple.
+        size:       Maximum number of elements in each tuple (a positive
+                    integer), or zero to have the original iterable yielded.
     """
+    assert isinstance(size, int) and size >= 0
+    if size == 0:
+        yield iterable
+        return
     iterator = iter(iterable)
     while True:
         iterator_slice = tuple(itertools.islice(iterator, size))

--- a/kcidb/mq/__init__.py
+++ b/kcidb/mq/__init__.py
@@ -82,7 +82,7 @@ class Publisher(ABC):
         Publish data to the message queue in the future.
 
         Args:
-            data:   The JSON data to publish to the message queue.
+            data:   The data to publish to the message queue.
                     Must adhere to a version of I/O schema.
 
         Returns:
@@ -97,7 +97,7 @@ class Publisher(ABC):
         Publish data to the message queue.
 
         Args:
-            data:   The JSON data to publish to the message queue.
+            data:   The data to publish to the message queue.
                     Must adhere to a version of I/O schema.
 
         Returns:
@@ -110,10 +110,10 @@ class Publisher(ABC):
         Publish data returned by an iterator.
 
         Args:
-            data_iter:  An iterator returning the JSON data to publish to the
+            data_iter:  An iterator returning the data to publish to the
                         message queue. Each must adhere to a version of I/O
                         schema.
-            done_cb:    A function to call when a JSON data is successfully
+            done_cb:    A function to call when a data is successfully
                         published. Will be called with the publishing ID of
                         each data returned by the iterator, in order.
         """

--- a/kcidb/test_orm.py
+++ b/kcidb/test_orm.py
@@ -130,9 +130,11 @@ def pattern(base, child, obj_type_name, obj_id_set=None):
                              SCHEMA.types[obj_type_name], obj_id_set)
 
 
-def from_io(io_data):
+def from_io(io_data, max_objs=0):
     """Create a pattern from I/O with test schema"""
-    return kcidb.orm.Pattern.from_io(io_data, schema=SCHEMA)
+    assert isinstance(max_objs, int) and max_objs >= 0
+    return kcidb.orm.Pattern.from_io(io_data, schema=SCHEMA,
+                                     max_objs=max_objs)
 
 
 def test_pattern_parse_misc():
@@ -460,6 +462,21 @@ def test_pattern_from_io():
             {("origin:1",), ("origin:2",), ("origin:3",)}
         )
     }
+    assert from_io(io_data, max_objs=3) == {
+        pattern(
+            None, True, "checkout",
+            {("origin:1",), ("origin:2",), ("origin:3",)}
+        )
+    }
+    assert from_io(io_data, max_objs=2) == {
+        pattern(None, True, "checkout", {("origin:1",), ("origin:2",)}),
+        pattern(None, True, "checkout", {("origin:3",)})
+    }
+    assert from_io(io_data, max_objs=1) == {
+        pattern(None, True, "checkout", {("origin:1",)}),
+        pattern(None, True, "checkout", {("origin:2",)}),
+        pattern(None, True, "checkout", {("origin:3",)})
+    }
 
     io_data = {
         "builds": [
@@ -516,6 +533,16 @@ def test_pattern_from_io():
         **kcidb.io.SCHEMA.new()
     }
     assert from_io(io_data) == {
+        pattern(None, True, "checkout", {("origin:1",)}),
+        pattern(None, True, "build", {("origin:2",)}),
+        pattern(None, True, "test", {("origin:3",)}),
+    }
+    assert from_io(io_data, max_objs=1) == {
+        pattern(None, True, "checkout", {("origin:1",)}),
+        pattern(None, True, "build", {("origin:2",)}),
+        pattern(None, True, "test", {("origin:3",)}),
+    }
+    assert from_io(io_data, max_objs=2) == {
         pattern(None, True, "checkout", {("origin:1",)}),
         pattern(None, True, "build", {("origin:2",)}),
         pattern(None, True, "test", {("origin:3",)}),

--- a/main.py
+++ b/main.py
@@ -270,6 +270,7 @@ def kcidb_spool_notifications(event, context):
     pattern_set = set()
     for line in base64.b64decode(event["data"]).decode().splitlines():
         pattern_set |= kcidb.orm.Pattern.parse(line)
+    LOGGER.info("RECEIVED %u PATTERNS", len(pattern_set))
     LOGGER.debug(
         "PATTERNS:\n%s",
         "".join(repr(p) + "\n" for p in pattern_set)


### PR DESCRIPTION
Limit the number of object IDs per pattern, not number of patterns, as those can still get arbitrarily large, and limiting them doesn't have the effect of limiting the load on the spooling Cloud Function we aimed for.