### PR TITLE
Doc: Removing release mentions

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -15,10 +15,6 @@ Where `<SOURCE>` is the location of the package source, e.g. a git repo:
 
     pip3 install --user git+https://github.com/kernelci/kcidb.git
 
-a (release) tag in a git repo:
-
-    pip3 install --user git+https://github.com/kernelci/kcidb.git@v9
-
 or a directory path:
 
     pip3 install --user .

--- a/doc/submitter_guide.md
+++ b/doc/submitter_guide.md
@@ -60,12 +60,15 @@ dashboard](https://kcidb.kernelci.org/).
 2\. Install KCIDB
 -----------------
 
-Pick a KCIDB [release][releases]. Latest would normally be best.
 
-Let's say you picked v9. Run this:
+KCIDB employs continuous integration and delivery, and aims to keep
+the code working at all times.
+
+Please install the latest version from GitHub:
+
 
 ```bash
-pip3 install --user 'git+https://git@github.com/kernelci/kcidb.git@v9'
+pip3 install --user 'git+https://git@github.com/kernelci/kcidb.git'
 ```
 
 Then make sure your PATH includes the `~/.local/bin` directory, e.g. with:
@@ -95,11 +98,10 @@ exit status.
 3\. Generate some report data
 -----------------------------
 
-KCIDB accepts data in JSON, described by a versioned schema. The
-`kcidb-schema` tool will output the current schema version. However, all tools
-will accept data complying with older schema versions, as a rule. Any
-exceptions to that will be mentioned in KCIDB release notes. Pipe your data
-into `kcidb-validate` tool to check if it will be accepted.
+`kcidb-schema` tool will output the current schema version.
+
+However, all tools will accept data complying with older schema versions. Pipe
+your data into `kcidb-validate` tool to check if it will be accepted.
 
 Here's a minimal report, containing no data:
 
@@ -406,7 +408,6 @@ let you, kernel developers, and KCIDB developers see how it works, what
 changes/additions might be needed to both your data and KCIDB, and improve our
 reporting faster!
 
-[releases]: https://github.com/kernelci/kcidb/releases
 [datetime_format]: https://tools.ietf.org/html/rfc3339#section-5.6
 [tests]: https://github.com/kernelci/kcidb/blob/master/tests.yaml
 [dashboard]: https://kcidb.kernelci.org/


### PR DESCRIPTION
These changes will allow users to download the main branch instead of latest version.
@spbnick Need reviews.

Fixes #353 