### PR TITLE
tests: Ignore SSL errors when validating

### DIFF
--- a/kcidb/tests/__init__.py
+++ b/kcidb/tests/__init__.py
@@ -22,4 +22,9 @@ def validate_main():
     schema.validate(catalog)
     if args.urls:
         for test in catalog.values():
-            requests.head(test['home'], timeout=60).raise_for_status()
+            try:
+                requests.head(test['home'], timeout=60).raise_for_status()
+            except requests.exceptions.SSLError:
+                requests.head(
+                    test['home'], timeout=60, verify=False
+                ).raise_for_status()


### PR DESCRIPTION
Ignore SSL errors (such as invalid or expired certificate) when validating the test catalog, since we're only verifying that the resource is there, and because that happens sometimes due to neglect, and not because the test's website went away. Otherwise our CI breaks.