### PR TITLE
doc: Issue and PR templates added

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,25 @@
+name: Bug
+description: Report an issue to help improve the project.
+title: "[Bug] "
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A brief description of the question or issue, also include what you tried and what didn't work
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Please add screenshots if applicable
+    validations:
+      required: false
+  - type: textarea
+    id: extrainfo
+    attributes:
+      label: Additional information
+      description: Is there anything else we should know about this bug?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/doc.yaml
+++ b/.github/ISSUE_TEMPLATE/doc.yaml
@@ -1,0 +1,25 @@
+name: Documentation issue
+description: Found an issue in the documentation? You can use this one!
+title: "[DOCS] <description>"
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A brief description of the question or issue, also include what you tried and what didn't work
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Please add screenshots if applicable
+    validations:
+      required: false
+  - type: textarea
+    id: extrainfo
+    attributes:
+      label: Additional information
+      description: Is there anything else we should know about this issue?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,0 +1,43 @@
+name: "Feature Request"
+description: Suggest a new feature for kcidb.
+title: "[Feature] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please explain the new feature.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: Describe the problem.
+      placeholder: A clear and concise description of the problem statement.
+      # value: "asdf"
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solution Description
+      description: Describe the solution you'd like.
+      placeholder: A clear and concise description of what you want to happen.
+      # value: "asdf"
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any additional context to this enhancement request.
+      placeholder: Add any other context or screenshots about the feature request here.
+      # value: "asdf"
+    validations:
+      required: false
+  - type: input
+    id: slack
+    attributes:
+      label: Slack discussion
+      description: If this feature request is the result of a discussion thread on Slack, please provide the link to the discussion for reference.
+      # placeholder: ex. email@example.com
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Explanation
+
+<!--
+In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.
+
+THIS IS MANDATORY.
+-->
+
+## Related issue
+
+<!--
+Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. 
+-->
+
+## What type of PR is this
+
+<!--
+
+> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
+> /kind bug
+> /kind documentation
+> /kind feature
+-->
+
+## Proposed Changes
+
+<!--
+Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 
+-->
+


### PR DESCRIPTION
Issue and PR template added for kcidb repo, this will give a structured way to raise and issue, and pull requests to the repo which will leverage the understanding of an issue and linked a proposed solution through a PR.

closes #390 

@spbnick need reviews