### PR TITLE
Add pre-commit hook script

### DIFF
--- a/.github-workflow-script
+++ b/.github-workflow-script
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Extract steps containing special env variable KCIDB_HOOKS from Github workflow"""
+import yaml
+import argparse
+
+# Parse command-line arguments
+parser = argparse.ArgumentParser()
+parser.add_argument("workflow_file",
+                    help="Path to the GitHub Actions workflow file")
+
+args = parser.parse_args()
+
+# Load the GitHub Actions workflow file as YAML
+with open(args.workflow_file, "r") as file:
+    data = yaml.safe_load(file)
+
+print("#!/bin/bash")
+# Loop over all jobs
+for job_name, job in data["jobs"].items():
+    # Loop over all steps in the job
+    for step in job["steps"]:
+        # Check if the step has a KCIDB_HOOKS environment variable
+        if "env" in step and step["env"].get("KCIDB_HOOKS") == "pre-commit":
+            # Print the name of the step
+            print(f"\n# {step['name']}")
+            # Extract the command(s) from the step
+            command = step.get("run", [])
+            # Print the command(s)
+            for line in command if isinstance(command, list) else [command]:
+                print(line)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Test with pytest
         run: KCIDB_IO_HEAVY_ASSERTS=1 KCIDB_HEAVY_ASSERTS=1 pytest --tb=native
 
-  check_auxilary_files:
+  check_auxiliary_files:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,10 +58,16 @@ jobs:
           pip3 install --upgrade '.[dev]'
       - name: Check python sources with flake8
         run: "flake8 kcidb *.py"
+        env:
+          KCIDB_HOOKS: "pre-commit"
       - name: Check python sources with pylint
         run: "pylint kcidb *.py"
+        env:
+          KCIDB_HOOKS: "pre-commit"
       - name: Test with pytest
         run: KCIDB_IO_HEAVY_ASSERTS=1 KCIDB_HEAVY_ASSERTS=1 pytest --tb=native
+        env:
+          KCIDB_HOOKS: "pre-commit"
 
   check_auxiliary_files:
 
@@ -83,6 +89,8 @@ jobs:
           pip3 install --upgrade '.[dev]'
       - name: Check YAML files with yamllint
         run: find -name '*.yaml' -or -name '*.yml' | xargs yamllint
+        env:
+          KCIDB_HOOKS: "pre-commit"
       - name: Check test catalog is ordered alphabetically
         run: |
           test_list=$(
@@ -100,6 +108,8 @@ jobs:
                   echo "$test_list_diff" >&2
                   false
               }
+        env:
+          KCIDB_HOOKS: "pre-commit"
       - name: Validate test catalog
         run: kcidb-tests-validate --urls < tests.yaml
 

--- a/.pre-commit
+++ b/.pre-commit
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=$(git hash-object -t tree /dev/null)
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+allownonascii=$(git config --bool hooks.allownonascii || echo "false")
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Cross platform projects tend to avoid non-ASCII filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if [ "$allownonascii" != "true" ] &&
+	# Note that the use of brackets around a tr range is ok here, (it's
+	# even required, for portability to Solaris 10's /usr/bin/tr), since
+	# the square bracket bytes happen to fall in the designated range.
+	test $(git diff --cached --name-only --diff-filter=A -z $against |
+	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+then
+	cat <<\EOF
+Error: Attempt to add a non-ASCII file name.
+
+This can cause problems if you want to work with people on other platforms.
+
+To be portable it is advisable to rename the file.
+
+If you know what you are doing you can disable this check using:
+
+  git config hooks.allownonascii true
+EOF
+	exit 1
+fi
+
+# If there are whitespace errors, print the offending file names and fail.
+git diff-index --check --cached $against --
+
+# Execute steps extracted from GitHub Actions
+. <(./.github-workflow-script .github/workflows/test.yml)

--- a/doc/developer_guide.md
+++ b/doc/developer_guide.md
@@ -22,6 +22,30 @@ Then make sure your PATH includes the `~/.local/bin` directory, e.g. with:
 
     export PATH="$PATH":~/.local/bin
 
+### Pre-commit hooks
+
+Git hooks are scripts that can be triggered automatically by Git when
+certain events occur, such as committing changes to a repository.
+They are typically used to enforce coding standards, perform automated
+tests, or perform other checks on code changes before they are committed.
+
+There are two main components in the setup 1) `.pre-commit` script and
+2) `.github-workflow-script`. The `.github-workflow-script` extracts the
+steps directly from the GitHub workflow, while a `.pre-commit `script will
+run the extracted commands.
+
+To leverage the setup, symlink the `.pre-commit` script into the git
+pre-commit hook (`.git/hooks/pre-commit`). We can do that using a
+simple command in the terminal. Make sure you are in the root
+directory of the project.
+
+    ln -s ../../.pre-commit .git/hooks/pre-commit
+
+Now, every time you run git commit, the pre-commit hook script will be
+executed before the commit is created. If any of the pre-commit checks
+fail, the commit will be aborted and you will see an error message
+explaining the issue.
+
 Guidelines
 ----------
 


### PR DESCRIPTION
Added feature: pre-commit 
closes #401
checks against flake8 and black for now. 
@spbnick Is this the correct method? Which one should we add and (possibly remove ) in this?
Also, we will require to make changes in documentation and specify the user to use the pre-commit install cmd after installation.
PS: pre-commit black changed the formatting. If it is not required we can remove that.