### PR TITLE
switch from mocks to pytest fixtures

### DIFF
--- a/kcidb/db/__init__.py
+++ b/kcidb/db/__init__.py
@@ -74,6 +74,7 @@ class Client(kcidb.orm.Source):
                                   driver
         """
         assert isinstance(database, str)
+        self.database = database
         self.driver = misc.instantiate_spec(DRIVER_TYPES, database)
         assert all(io_schema <= io.SCHEMA
                    for io_schema in self.driver.get_schemas().values()), \


### PR DESCRIPTION
The tests functions in kcidb/test_db.py switched from using mocks to pytests fixtures  and the database initialized in the client object constructor in kcidb/db/__init__.py to store its own database attribute @spbnick 