### PR TITLE
monitor: Disable Nikolai Kondrashov's subscription

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 *.egg-info
 *.pyc
+*.swp

--- a/kcidb/monitor/subscriptions/nikolai_kondrashov.py
+++ b/kcidb/monitor/subscriptions/nikolai_kondrashov.py
@@ -3,7 +3,7 @@
 from kcidb.monitor.output import NotificationMessage as Message
 
 
-def match_revision(revision):
+def _disabled_match_revision(revision):
     """Match revisions of interest to Nikolai Kondrashov"""
     subject_sfx = ' failed for {% include "revision_summary.txt.j2" %}'
     msg_args = dict(


### PR DESCRIPTION
Now that we have tests for actual deployments, we don't really need the
test subscription for Nikolai Kondrashov enabled. Let's disable it and
reduce the SPAM.