### PR TITLE
Update the mailing list details

### DIFF
--- a/doc/_index.md
+++ b/doc/_index.md
@@ -8,6 +8,6 @@ KCIDB is a package for submitting and querying Linux Kernel CI reports, coming
 from independent CI systems, and for maintaining the service behind that.
 
 See the collected results on [our dashboard](https://kcidb.kernelci.org/).
-Write to [kernelci@groups.io](mailto:kernelci@groups.io) if you want to start
+Write to [kernelci@lists.linux.dev](mailto:kernelci@lists.linux.dev) if you want to start
 submitting results from your CI system, or if you want to receive automatic
 notifications of arriving results.

--- a/doc/submitter_guide.md
+++ b/doc/submitter_guide.md
@@ -19,7 +19,7 @@ Python 3 library, if you're feeling fancy).
 1\. Get submission credentials and parameters
 ---------------------------------------------
 
-Write to [kernelci@groups.io](mailto:kernelci@groups.io), introduce yourself,
+Write to [kernelci@lists.linux.dev](mailto:kernelci@lists.linux.dev), introduce yourself,
 and explain what you want to submit (better, show preliminary report data).
 Once your request is approved, you will get a JSON credentials file, which you
 can use to authenticate yourself with KCIDB tools/library.


### PR DESCRIPTION
kernelci@groups.io mailing list is no longer used
for comminuication and is replaced by new list
kernelci@lists.linux.dev

Signed-off-by: Misbah Anjum N <misanjum@linux.vnet.ibm.com>