### PR TITLE
tests: Increase email timeout to handle disconnects

### DIFF
--- a/kcidb/test_monitor.py
+++ b/kcidb/test_monitor.py
@@ -816,7 +816,7 @@ def test_email_generated(empty_deployment):
         # check we get one correct message per object type
         remaining_obj_types = obj_types.copy()
         for ack_id, email in \
-                email_subscriber.pull_iter(len(remaining_obj_types), 600):
+                email_subscriber.pull_iter(len(remaining_obj_types), 1800):
             email_subscriber.ack(ack_id)
             assert email['From'] == "bot@kernelci.org", \
                 f"Email From incorrect for {io_version!r}"


### PR DESCRIPTION
Increase timeout for receiving generated emails in test_email_generated (back) to 30 minutes to handle the occasional PostgreSQL disconnects and message queue delivery retries, which take a while.

A better fix would be to make the PostgreSQL driver retry queries, but it's not a trivial task and would take a bit to implement.