### PR TITLE
cloud: Add kcidb_cache_urls to cloud func withdraw

### DIFF
--- a/cloud
+++ b/cloud
@@ -1495,6 +1495,7 @@ function cloud_functions_withdraw() {
     cloud_function_withdraw "$project" "${prefix}pick_notifications"
     cloud_function_withdraw "$project" "${prefix}send_notification"
     cloud_function_withdraw "$project" "${prefix}spool_notifications"
+    cloud_function_withdraw "$project" "${prefix}cache_urls"
     cloud_function_withdraw "$project" "${prefix}load_queue"
 }
 


### PR DESCRIPTION
Added `cloud_function_withdraw "$project" "${prefix}cache_urls" ` to the withdrawing section in the cloud script. Before it was not withdrawing it only deploying it. 

Need reviews @spbnick 