### PR TITLE
reformat public url return value

### DIFF
--- a/kcidb/cache/__init__.py
+++ b/kcidb/cache/__init__.py
@@ -114,8 +114,10 @@ class Client:
         Returns:
             The public URL of the (potentially) cached URL.
         """
-        return f"https://storage.googleapis.com/ \
-            {self.bucket_name}/{self._format_object_name(url)}"
+        return (
+            f"https://storage.googleapis.com/"
+            f"{self.bucket_name}/{self._format_object_name(url)}"
+        )
 
     def map(self, url):
         """


### PR DESCRIPTION
reformat public url return value in `_format_public_url` of `cache` client. This will fix the white spaces that were leading in the redirection URL generated by `_format_public_url` 