### PR TITLE
Fix invalid message processing

### DIFF
--- a/kcidb/mq/__init__.py
+++ b/kcidb/mq/__init__.py
@@ -400,7 +400,11 @@ class IOSubscriber(Subscriber):
         Raises:
             An exception in case data decoding failed.
         """
-        return self.schema.upgrade(json.loads(message_data.decode()))
+        return self.schema.upgrade(
+            self.schema.validate(
+                json.loads(message_data.decode())
+            )
+        )
 
     def __init__(self, *args, schema=io.SCHEMA, **kwargs):
         """

--- a/main.py
+++ b/main.py
@@ -223,9 +223,11 @@ def kcidb_load_queue(event, context):
             pattern_set |= \
                 kcidb.orm.query.Pattern.parse(repr(pattern) + "<*#")
 
-        # Publish patterns matching all affected objects
-        publisher.publish(pattern_set)
-        LOGGER.info("Published updates made by %u loaded objects", obj_num)
+        # Publish patterns matching all affected objects, if any
+        if pattern_set:
+            publisher.publish(pattern_set)
+            LOGGER.info("Published updates made by %u loaded objects",
+                        obj_num)
 
 
 def kcidb_spool_notifications(event, context):


### PR DESCRIPTION
This fixes the submission queue blockage due to invalid messages not being safely discarded, trying to make their way into the database, failing, and aborting the `kcidb_load_queue` Cloud Function. We've had this problem before, and it resurfaced because of refactoring of I/O validation. There's now an [issue](https://github.com/kernelci/kcidb/issues/460) about making a test for this.