### PR TITLE
Update in increase max instances and reduce timeout for kcidb_cache_redirect

### DIFF
--- a/cloud
+++ b/cloud
@@ -1491,8 +1491,8 @@ function cloud_functions_deploy() {
                           --trigger-http \
                           --allow-unauthenticated \
                           --memory 256MB \
-                          --max-instances=1 \
-                          --timeout 540
+                          --max-instances=16 \
+                          --timeout 30
 
     cloud_function_deploy "$project" "${prefix}load_queue" \
                           "$source" \


### PR DESCRIPTION
 Increased max instances and reduced timeout for the `kcidb_cache_redirect` cloud function.


Need reviews @spbnick 