### PR TITLE
Support deploying and withdrawing specific Cloud Functions

### DIFF
--- a/cloud
+++ b/cloud
@@ -1311,16 +1311,19 @@ function storage_withdraw() {
 declare -r CLOUD_FUNCTION_REGION="us-central1"
 
 # Deploy a Cloud Function
-# Args: source project prefix name [param_arg...]
+# Args: sections source project prefix name [param_arg...]
 function cloud_function_deploy() {
+    declare -r sections="$1"; shift
     declare -r source="$1"; shift
     declare -r project="$1"; shift
     declare -r prefix="$1"; shift
     declare -r name="$1"; shift
-    verbose echo "    Deploying ${name@Q}"
-    mute gcloud functions deploy --quiet --project="$project" \
-                                 --region="$CLOUD_FUNCTION_REGION" \
-                                 --source "$source" "${prefix}${name}" "$@"
+    sections_run_explicit "$sections" \
+        "cloud_functions.$name" deploy \
+        mute gcloud functions deploy --quiet --project="$project" \
+                                     --region="$CLOUD_FUNCTION_REGION" \
+                                     --source "$source" "${prefix}${name}" \
+                                     "$@"
 }
 
 # Delete a Cloud Function (without complaining it doesn't exist).
@@ -1336,13 +1339,15 @@ function cloud_function_delete()
 }
 
 # Delete a Cloud Function if it exists
-# Args: project prefix name
+# Args: sections project prefix name
 function cloud_function_withdraw() {
+    declare -r sections="$1"; shift
     declare -r project="$1"; shift
     declare -r prefix="$1"; shift
     declare -r name="$1"; shift
-    verbose echo "    Withdrawing ${name@Q}"
-    cloud_function_delete --quiet --project="$project" "${prefix}${name}"
+    sections_run_explicit "$sections" \
+        "cloud_functions.$name" withdraw \
+        cloud_function_delete --quiet --project="$project" "${prefix}${name}"
 }
 
 # Output deployment environment for Cloud Functions
@@ -1448,7 +1453,8 @@ function cloud_functions_env() {
 }
 
 # Deploy Cloud Functions
-# Args: --project=NAME --prefix=PREFIX --source=PATH
+# Args: --sections=GLOB
+#       --project=NAME --prefix=PREFIX --source=PATH
 #       --load-queue-trigger-topic=NAME
 #       --pick-notifications-trigger-topic=NAME
 #       --updated-urls-topic=NAME
@@ -1457,7 +1463,7 @@ function cloud_functions_env() {
 #       --cache-redirect-function-name=NAME
 #       --env-yaml=YAML
 function cloud_functions_deploy() {
-    params="$(getopt_vars project prefix source \
+    params="$(getopt_vars sections project prefix source \
                           load_queue_trigger_topic \
                           pick_notifications_trigger_topic \
                           updated_urls_topic \
@@ -1479,7 +1485,7 @@ function cloud_functions_deploy() {
     trigger_event+="document.create"
     declare trigger_resource="projects/$project/databases/(default)/documents/"
     trigger_resource+="${spool_collection_path}/{notification_id}"
-    cloud_function_deploy "$source" "$project" "$prefix" \
+    cloud_function_deploy "$sections" "$source" "$project" "$prefix" \
                           pick_notifications \
                           --entry-point kcidb_pick_notifications\
                           --env-vars-file "$env_yaml_file" \
@@ -1489,7 +1495,7 @@ function cloud_functions_deploy() {
                           --max-instances=1 \
                           --timeout 540
 
-    cloud_function_deploy "$source" "$project" "$prefix" \
+    cloud_function_deploy "$sections" "$source" "$project" "$prefix" \
                           send_notification \
                           --entry-point kcidb_send_notification \
                           --env-vars-file "$env_yaml_file" \
@@ -1501,7 +1507,7 @@ function cloud_functions_deploy() {
                           --max-instances=1 \
                           --timeout 540
 
-    cloud_function_deploy "$source" "$project" "$prefix" \
+    cloud_function_deploy "$sections" "$source" "$project" "$prefix" \
                           spool_notifications \
                           --entry-point kcidb_spool_notifications \
                           --env-vars-file "$env_yaml_file" \
@@ -1511,7 +1517,7 @@ function cloud_functions_deploy() {
                           --max-instances=10 \
                           --timeout 540
 
-    cloud_function_deploy "$source" "$project" "$prefix" \
+    cloud_function_deploy "$sections" "$source" "$project" "$prefix" \
                           cache_urls \
                           --entry-point kcidb_cache_urls \
                           --env-vars-file "$env_yaml_file" \
@@ -1521,7 +1527,7 @@ function cloud_functions_deploy() {
                           --max-instances=1 \
                           --timeout 540
 
-    cloud_function_deploy "$source" "$project" "$prefix" \
+    cloud_function_deploy "$sections" "$source" "$project" "$prefix" \
                           "$cache_redirect_function_name" \
                           --entry-point \
                           "kcidb_${cache_redirect_function_name}" \
@@ -1533,7 +1539,7 @@ function cloud_functions_deploy() {
                           --max-instances=16 \
                           --timeout 30
 
-    cloud_function_deploy "$source" "$project" "$prefix" \
+    cloud_function_deploy "$sections" "$source" "$project" "$prefix" \
                           load_queue \
                           --entry-point kcidb_load_queue \
                           --env-vars-file "$env_yaml_file" \
@@ -1547,20 +1553,25 @@ function cloud_functions_deploy() {
 }
 
 # Withdraw Cloud Functions
-# Args: --project=NAME --prefix=PREFIX
+# Args: --sections=GLOB --project=NAME --prefix=PREFIX
 #       --cache-redirect-function-name=NAME
 function cloud_functions_withdraw() {
-    params="$(getopt_vars project prefix \
+    params="$(getopt_vars sections project prefix \
                           cache_redirect_function_name \
                           -- "$@")"
     eval "$params"
-    cloud_function_withdraw "$project" "$prefix" pick_notifications
-    cloud_function_withdraw "$project" "$prefix" send_notification
-    cloud_function_withdraw "$project" "$prefix" spool_notifications
-    cloud_function_withdraw "$project" "$prefix" cache_urls
-    cloud_function_withdraw "$project" \
-                            "$prefix" "$cache_redirect_function_name"
-    cloud_function_withdraw "$project" "$prefix" load_queue
+    cloud_function_withdraw "$sections" "$project" "$prefix" \
+                            pick_notifications
+    cloud_function_withdraw "$sections" "$project" "$prefix" \
+                            send_notification
+    cloud_function_withdraw "$sections" "$project" "$prefix" \
+                            spool_notifications
+    cloud_function_withdraw "$sections" "$project" "$prefix" \
+                            cache_urls
+    cloud_function_withdraw "$sections" "$project" "$prefix" \
+                            "$cache_redirect_function_name"
+    cloud_function_withdraw "$sections" "$project" "$prefix" \
+                            load_queue
 }
 
 # Check if a scheduler job exists
@@ -1736,7 +1747,12 @@ declare -A -r SECTIONS=(
     ["secrets"]="Secrets"
     ["firestore"]="Firestore database"
     ["storage"]="Google cloud storage"
-    ["cloud_functions"]="Cloud Functions"
+    ["cloud_functions.pick_notifications"]="Cloud Functions: kcidb_pick_notifications()"
+    ["cloud_functions.send_notification"]="Cloud Functions: kcidb_send_notification()"
+    ["cloud_functions.spool_notifications"]="Cloud Functions: kcidb_spool_notifications()"
+    ["cloud_functions.cache_redirect"]="Cloud Functions: kcidb_cache_redirect()"
+    ["cloud_functions.cache_urls"]="Cloud Functions: kcidb_cache_urls()"
+    ["cloud_functions.load_queue"]="Cloud Functions: kcidb_load_queue()"
     ["scheduler"]="Scheduler jobs"
     ["submitters"]="Submitter permissions"
 )
@@ -2058,7 +2074,8 @@ function execute_command() {
             --smtp-subscription="$smtp_subscription"
         sections_run "$sections" firestore_deploy "$project"
         sections_run "$sections" storage_deploy "$project" "$cache_bucket_name"
-        sections_run "$sections" cloud_functions_deploy \
+        cloud_functions_deploy \
+            --sections="$sections" \
             --project="$project" \
             --prefix="$prefix" \
             --source="$(dirname "$(realpath "$0")")" \
@@ -2089,7 +2106,8 @@ function execute_command() {
         sections_run "$sections" submitters_withdraw \
             "$project" "$new_topic" "${submitters[@]}"
         sections_run "$sections" scheduler_withdraw "$project" "$prefix"
-        sections_run "$sections" cloud_functions_withdraw \
+        cloud_functions_withdraw \
+            --sections="$sections" \
             --project="$project" \
             --prefix="$prefix" \
             --cache-redirect-function-name="$cache_redirect_function_name"

--- a/cloud
+++ b/cloud
@@ -1323,6 +1323,7 @@ function cloud_function_deploy() {
         mute gcloud functions deploy --quiet --project="$project" \
                                      --region="$CLOUD_FUNCTION_REGION" \
                                      --source "$source" "${prefix}${name}" \
+                                     --entry-point "kcidb_${name}" \
                                      "$@"
 }
 
@@ -1487,7 +1488,6 @@ function cloud_functions_deploy() {
     trigger_resource+="${spool_collection_path}/{notification_id}"
     cloud_function_deploy "$sections" "$source" "$project" "$prefix" \
                           pick_notifications \
-                          --entry-point kcidb_pick_notifications\
                           --env-vars-file "$env_yaml_file" \
                           --runtime python37 \
                           --trigger-topic "${pick_notifications_trigger_topic}" \
@@ -1497,7 +1497,6 @@ function cloud_functions_deploy() {
 
     cloud_function_deploy "$sections" "$source" "$project" "$prefix" \
                           send_notification \
-                          --entry-point kcidb_send_notification \
                           --env-vars-file "$env_yaml_file" \
                           --runtime python37 \
                           --trigger-event "${trigger_event}" \
@@ -1509,7 +1508,6 @@ function cloud_functions_deploy() {
 
     cloud_function_deploy "$sections" "$source" "$project" "$prefix" \
                           spool_notifications \
-                          --entry-point kcidb_spool_notifications \
                           --env-vars-file "$env_yaml_file" \
                           --runtime python37 \
                           --trigger-topic "${updated_topic}" \
@@ -1519,7 +1517,6 @@ function cloud_functions_deploy() {
 
     cloud_function_deploy "$sections" "$source" "$project" "$prefix" \
                           cache_urls \
-                          --entry-point kcidb_cache_urls \
                           --env-vars-file "$env_yaml_file" \
                           --runtime python37 \
                           --trigger-topic "${updated_urls_topic}" \
@@ -1529,8 +1526,6 @@ function cloud_functions_deploy() {
 
     cloud_function_deploy "$sections" "$source" "$project" "$prefix" \
                           "$cache_redirect_function_name" \
-                          --entry-point \
-                          "kcidb_${cache_redirect_function_name}" \
                           --env-vars-file "$env_yaml_file" \
                           --runtime python37 \
                           --trigger-http \
@@ -1541,7 +1536,6 @@ function cloud_functions_deploy() {
 
     cloud_function_deploy "$sections" "$source" "$project" "$prefix" \
                           load_queue \
-                          --entry-point kcidb_load_queue \
                           --env-vars-file "$env_yaml_file" \
                           --runtime python37 \
                           --trigger-topic "${load_queue_trigger_topic}" \

--- a/cloud
+++ b/cloud
@@ -1760,7 +1760,6 @@ function sections_run() {
     declare -r name="${command%_*}"
     declare -r verb="${command##*_}"
     declare -r action="${verb}ing"
-    declare status
 
     if [ -z "$name" ]; then
         echo "No section name found in command name ${command@Q}" >&2

--- a/cloud
+++ b/cloud
@@ -1513,7 +1513,8 @@ function cloud_functions_deploy() {
                           --max-instances=1 \
                           --timeout 540
 
-    cloud_function_deploy "$project" "${cache_redirect_function_name}" \
+    cloud_function_deploy "$project" \
+                          "${prefix}${cache_redirect_function_name}" \
                           "$source" \
                           --entry-point kcidb_cache_redirect \
                           --env-vars-file "$env_yaml_file" \
@@ -1549,7 +1550,8 @@ function cloud_functions_withdraw() {
     cloud_function_withdraw "$project" "${prefix}send_notification"
     cloud_function_withdraw "$project" "${prefix}spool_notifications"
     cloud_function_withdraw "$project" "${prefix}cache_urls"
-    cloud_function_withdraw "$project" "${cache_redirect_function_name}"
+    cloud_function_withdraw "$project" \
+                            "${prefix}${cache_redirect_function_name}"
     cloud_function_withdraw "$project" "${prefix}load_queue"
 }
 
@@ -1852,9 +1854,11 @@ function execute_command() {
     declare -r load_queue_trigger_topic="${prefix}load_queue_trigger"
     declare -r cache_bucket_name="${project}_${prefix}cache"
     declare -r pick_notifications_trigger_topic="${prefix}pick_notifications_trigger"
-    declare -r cache_redirect_function_name="${prefix}cache_redirect"
-    declare cache_redirector_url="https://${CLOUD_FUNCTION_REGION}-${project}.cloud"
-    declare -r cache_redirector_url+="functions.net/${cache_redirect_function_name}"
+    declare -r cache_redirect_function_name="cache_redirect"
+    declare cache_redirector_url="https://${CLOUD_FUNCTION_REGION}"
+    declare cache_redirector_url+="-${project}.cloudfunctions.net/"
+    declare cache_redirector_url+="${prefix}"
+    declare -r cache_redirector_url+="${cache_redirect_function_name}"
     declare -r updated_urls_topic="${prefix}updated_urls"
     declare -r new_topic="${prefix}new"
     declare -r new_load_subscription="${prefix}new_load"

--- a/cloud
+++ b/cloud
@@ -1516,15 +1516,6 @@ function cloud_functions_deploy() {
                           --timeout 540
 
     cloud_function_deploy "$sections" "$source" "$project" "$prefix" \
-                          cache_urls \
-                          --env-vars-file "$env_yaml_file" \
-                          --runtime python37 \
-                          --trigger-topic "${updated_urls_topic}" \
-                          --memory 256MB \
-                          --max-instances=1 \
-                          --timeout 540
-
-    cloud_function_deploy "$sections" "$source" "$project" "$prefix" \
                           "$cache_redirect_function_name" \
                           --env-vars-file "$env_yaml_file" \
                           --runtime python37 \
@@ -1533,6 +1524,15 @@ function cloud_functions_deploy() {
                           --memory 256MB \
                           --max-instances=16 \
                           --timeout 30
+
+    cloud_function_deploy "$sections" "$source" "$project" "$prefix" \
+                          cache_urls \
+                          --env-vars-file "$env_yaml_file" \
+                          --runtime python37 \
+                          --trigger-topic "${updated_urls_topic}" \
+                          --memory 256MB \
+                          --max-instances=1 \
+                          --timeout 540
 
     cloud_function_deploy "$sections" "$source" "$project" "$prefix" \
                           load_queue \
@@ -1561,9 +1561,9 @@ function cloud_functions_withdraw() {
     cloud_function_withdraw "$sections" "$project" "$prefix" \
                             spool_notifications
     cloud_function_withdraw "$sections" "$project" "$prefix" \
-                            cache_urls
-    cloud_function_withdraw "$sections" "$project" "$prefix" \
                             "$cache_redirect_function_name"
+    cloud_function_withdraw "$sections" "$project" "$prefix" \
+                            cache_urls
     cloud_function_withdraw "$sections" "$project" "$prefix" \
                             load_queue
 }

--- a/cloud
+++ b/cloud
@@ -1322,19 +1322,25 @@ function cloud_function_deploy() {
                                  --source "$source" "$name" "$@"
 }
 
+# Delete a Cloud Function (without complaining it doesn't exist).
+# Accepts the arguments of "gcloud functions delete".
+function cloud_function_delete()
+{
+    declare output
+    if ! output=$(gcloud functions delete "$@" 2>&1) &&
+       [[ $output != *\ status=\[404\]* ]]; then
+        echo "$output" >&2
+        false
+    fi
+}
+
 # Delete a Cloud Function if it exists
 # Args: project name
 function cloud_function_withdraw() {
     declare -r project="$1"; shift
     declare -r name="$1"; shift
-    declare output
     verbose echo "    Withdrawing ${name@Q}"
-    if ! output=$(
-            gcloud functions delete --quiet --project="$project" "$name" 2>&1
-       ) && [[ $output != *\ status=\[404\]* ]]; then
-        echo "$output" >&2
-        false
-    fi
+    cloud_function_delete --quiet --project="$project" "name"
 }
 
 # Output deployment environment for Cloud Functions

--- a/cloud
+++ b/cloud
@@ -2417,12 +2417,13 @@ function execute() {
         fi
         declare glob="${1:-*}"
         declare name
-        for name in "${!SECTIONS[@]}"; do
-            if [[ $name == $glob ]]; then
-                printf "%-${SECTIONS_NAME_LEN_MAX}s %s\\n" \
-                       "$name" "${SECTIONS[$name]}"
-            fi
-        done
+        printf '%s\n' "${!SECTIONS[@]}" | sort |
+            while read -r name; do
+                if [[ $name == $glob ]]; then
+                    printf "%-${SECTIONS_NAME_LEN_MAX}s %s\\n" \
+                           "$name" "${SECTIONS[$name]}"
+                fi
+            done
         exit 0
     elif [ "$command" == "shell" ]; then
         if (( $# < 2 )); then

--- a/cloud
+++ b/cloud
@@ -1311,12 +1311,12 @@ function storage_withdraw() {
 declare -r CLOUD_FUNCTION_REGION="us-central1"
 
 # Deploy a Cloud Function
-# Args: project prefix name source [param_arg...]
+# Args: source project prefix name [param_arg...]
 function cloud_function_deploy() {
+    declare -r source="$1"; shift
     declare -r project="$1"; shift
     declare -r prefix="$1"; shift
     declare -r name="$1"; shift
-    declare -r source="$1"; shift
     verbose echo "    Deploying ${name@Q}"
     mute gcloud functions deploy --quiet --project="$project" \
                                  --region="$CLOUD_FUNCTION_REGION" \
@@ -1479,8 +1479,8 @@ function cloud_functions_deploy() {
     trigger_event+="document.create"
     declare trigger_resource="projects/$project/databases/(default)/documents/"
     trigger_resource+="${spool_collection_path}/{notification_id}"
-    cloud_function_deploy "$project" "$prefix" pick_notifications \
-                          "$source" \
+    cloud_function_deploy "$source" "$project" "$prefix" \
+                          pick_notifications \
                           --entry-point kcidb_pick_notifications\
                           --env-vars-file "$env_yaml_file" \
                           --runtime python37 \
@@ -1489,8 +1489,8 @@ function cloud_functions_deploy() {
                           --max-instances=1 \
                           --timeout 540
 
-    cloud_function_deploy "$project" "$prefix" send_notification \
-                          "$source" \
+    cloud_function_deploy "$source" "$project" "$prefix" \
+                          send_notification \
                           --entry-point kcidb_send_notification \
                           --env-vars-file "$env_yaml_file" \
                           --runtime python37 \
@@ -1501,8 +1501,8 @@ function cloud_functions_deploy() {
                           --max-instances=1 \
                           --timeout 540
 
-    cloud_function_deploy "$project" "$prefix" spool_notifications \
-                          "$source" \
+    cloud_function_deploy "$source" "$project" "$prefix" \
+                          spool_notifications \
                           --entry-point kcidb_spool_notifications \
                           --env-vars-file "$env_yaml_file" \
                           --runtime python37 \
@@ -1511,8 +1511,8 @@ function cloud_functions_deploy() {
                           --max-instances=10 \
                           --timeout 540
 
-    cloud_function_deploy "$project" "$prefix" cache_urls \
-                          "$source" \
+    cloud_function_deploy "$source" "$project" "$prefix" \
+                          cache_urls \
                           --entry-point kcidb_cache_urls \
                           --env-vars-file "$env_yaml_file" \
                           --runtime python37 \
@@ -1521,9 +1521,8 @@ function cloud_functions_deploy() {
                           --max-instances=1 \
                           --timeout 540
 
-    cloud_function_deploy "$project" \
-                          "$prefix" "$cache_redirect_function_name" \
-                          "$source" \
+    cloud_function_deploy "$source" "$project" "$prefix" \
+                          "$cache_redirect_function_name" \
                           --entry-point \
                           "kcidb_${cache_redirect_function_name}" \
                           --env-vars-file "$env_yaml_file" \
@@ -1534,8 +1533,8 @@ function cloud_functions_deploy() {
                           --max-instances=16 \
                           --timeout 30
 
-    cloud_function_deploy "$project" "$prefix" load_queue \
-                          "$source" \
+    cloud_function_deploy "$source" "$project" "$prefix" \
+                          load_queue \
                           --entry-point kcidb_load_queue \
                           --env-vars-file "$env_yaml_file" \
                           --runtime python37 \

--- a/cloud
+++ b/cloud
@@ -1516,7 +1516,8 @@ function cloud_functions_deploy() {
     cloud_function_deploy "$project" \
                           "${prefix}${cache_redirect_function_name}" \
                           "$source" \
-                          --entry-point kcidb_cache_redirect \
+                          --entry-point \
+                          "kcidb_${cache_redirect_function_name}" \
                           --env-vars-file "$env_yaml_file" \
                           --runtime python37 \
                           --trigger-http \

--- a/cloud
+++ b/cloud
@@ -1749,28 +1749,20 @@ declare -r SECTIONS_NAME_LEN_MAX
 declare -r SECTIONS_DESCRIPTION_LEN_MAX
 
 # Execute an operation on a section of installation, if its name matches a
-# glob. The operation is defined as a command with arguments. The command name
-# must consist of the (multi-word) section name and the single-word operation
-# verb, with all words separated by underscores.
+# glob. The section name is passed as an explicit argument. The operation is
+# also passed explicitly as the operation verb, and the corresponding command
+# to execute.
 #
-# Args: glob command [arg...]
-function sections_run() {
+# Args: glob name verb command [arg...]
+function sections_run_explicit() {
     declare -r glob="$1"; shift
+    declare -r name="$1"; shift
+    declare -r verb="$1"; shift
     declare -r command="$1"; shift
-    declare -r name="${command%_*}"
-    declare -r verb="${command##*_}"
     declare -r action="${verb}ing"
 
-    if [ -z "$name" ]; then
-        echo "No section name found in command name ${command@Q}" >&2
-        exit 1
-    fi
     if ! [[ -v SECTIONS[$name] ]]; then
         echo "Unknown section name ${name@Q}" >&2
-        exit 1
-    fi
-    if [ -z "$verb" ]; then
-        echo "No operation verb found in command name ${command@Q}" >&2
         exit 1
     fi
 
@@ -1783,6 +1775,30 @@ function sections_run() {
     aterr_push "echo Failed ${action@Q} ${SECTIONS[$name]@Q} '['${name@Q}']'"
     "${command}" "$@"
     aterr_pop
+}
+
+# Execute an operation on a section of installation, if its name matches a
+# glob. The operation is defined as a command with arguments. The command name
+# must consist of the (multi-word) section name and the single-word operation
+# verb, with all words separated by underscores.
+#
+# Args: glob command [arg...]
+function sections_run() {
+    declare -r glob="$1"; shift
+    declare -r command="$1"; shift
+    declare -r name="${command%_*}"
+    declare -r verb="${command##*_}"
+
+    if [ -z "$name" ]; then
+        echo "No section name found in command name ${command@Q}" >&2
+        exit 1
+    fi
+    if [ -z "$verb" ]; then
+        echo "No operation verb found in command name ${command@Q}" >&2
+        exit 1
+    fi
+
+    sections_run_explicit "$glob" "$name" "$verb" "$command" "$@"
 }
 
 # Escape backslashes and whitespace with backslashes in text.

--- a/cloud
+++ b/cloud
@@ -1748,10 +1748,10 @@ unset SECTIONS_NAME
 declare -r SECTIONS_NAME_LEN_MAX
 declare -r SECTIONS_DESCRIPTION_LEN_MAX
 
-# Execute a operation on a section of installation, if its name matches a
+# Execute an operation on a section of installation, if its name matches a
 # glob. The operation is defined as a command with arguments. The command name
-# must consist of the section name and the operation verb separated by an
-# underscore.
+# must consist of the (multi-word) section name and the single-word operation
+# verb, with all words separated by underscores.
 #
 # Args: glob command [arg...]
 function sections_run() {

--- a/cloud
+++ b/cloud
@@ -1311,15 +1311,16 @@ function storage_withdraw() {
 declare -r CLOUD_FUNCTION_REGION="us-central1"
 
 # Deploy a Cloud Function
-# Args: project name source [param_arg...]
+# Args: project prefix name source [param_arg...]
 function cloud_function_deploy() {
     declare -r project="$1"; shift
+    declare -r prefix="$1"; shift
     declare -r name="$1"; shift
     declare -r source="$1"; shift
     verbose echo "    Deploying ${name@Q}"
     mute gcloud functions deploy --quiet --project="$project" \
                                  --region="$CLOUD_FUNCTION_REGION" \
-                                 --source "$source" "$name" "$@"
+                                 --source "$source" "${prefix}${name}" "$@"
 }
 
 # Delete a Cloud Function (without complaining it doesn't exist).
@@ -1335,12 +1336,13 @@ function cloud_function_delete()
 }
 
 # Delete a Cloud Function if it exists
-# Args: project name
+# Args: project prefix name
 function cloud_function_withdraw() {
     declare -r project="$1"; shift
+    declare -r prefix="$1"; shift
     declare -r name="$1"; shift
     verbose echo "    Withdrawing ${name@Q}"
-    cloud_function_delete --quiet --project="$project" "name"
+    cloud_function_delete --quiet --project="$project" "${prefix}${name}"
 }
 
 # Output deployment environment for Cloud Functions
@@ -1477,7 +1479,7 @@ function cloud_functions_deploy() {
     trigger_event+="document.create"
     declare trigger_resource="projects/$project/databases/(default)/documents/"
     trigger_resource+="${spool_collection_path}/{notification_id}"
-    cloud_function_deploy "$project" "${prefix}pick_notifications" \
+    cloud_function_deploy "$project" "$prefix" pick_notifications \
                           "$source" \
                           --entry-point kcidb_pick_notifications\
                           --env-vars-file "$env_yaml_file" \
@@ -1487,7 +1489,7 @@ function cloud_functions_deploy() {
                           --max-instances=1 \
                           --timeout 540
 
-    cloud_function_deploy "$project" "${prefix}send_notification" \
+    cloud_function_deploy "$project" "$prefix" send_notification \
                           "$source" \
                           --entry-point kcidb_send_notification \
                           --env-vars-file "$env_yaml_file" \
@@ -1499,7 +1501,7 @@ function cloud_functions_deploy() {
                           --max-instances=1 \
                           --timeout 540
 
-    cloud_function_deploy "$project" "${prefix}spool_notifications" \
+    cloud_function_deploy "$project" "$prefix" spool_notifications \
                           "$source" \
                           --entry-point kcidb_spool_notifications \
                           --env-vars-file "$env_yaml_file" \
@@ -1509,7 +1511,7 @@ function cloud_functions_deploy() {
                           --max-instances=10 \
                           --timeout 540
 
-    cloud_function_deploy "$project" "${prefix}cache_urls" \
+    cloud_function_deploy "$project" "$prefix" cache_urls \
                           "$source" \
                           --entry-point kcidb_cache_urls \
                           --env-vars-file "$env_yaml_file" \
@@ -1520,7 +1522,7 @@ function cloud_functions_deploy() {
                           --timeout 540
 
     cloud_function_deploy "$project" \
-                          "${prefix}${cache_redirect_function_name}" \
+                          "$prefix" "$cache_redirect_function_name" \
                           "$source" \
                           --entry-point \
                           "kcidb_${cache_redirect_function_name}" \
@@ -1532,7 +1534,7 @@ function cloud_functions_deploy() {
                           --max-instances=16 \
                           --timeout 30
 
-    cloud_function_deploy "$project" "${prefix}load_queue" \
+    cloud_function_deploy "$project" "$prefix" load_queue \
                           "$source" \
                           --entry-point kcidb_load_queue \
                           --env-vars-file "$env_yaml_file" \
@@ -1553,13 +1555,13 @@ function cloud_functions_withdraw() {
                           cache_redirect_function_name \
                           -- "$@")"
     eval "$params"
-    cloud_function_withdraw "$project" "${prefix}pick_notifications"
-    cloud_function_withdraw "$project" "${prefix}send_notification"
-    cloud_function_withdraw "$project" "${prefix}spool_notifications"
-    cloud_function_withdraw "$project" "${prefix}cache_urls"
+    cloud_function_withdraw "$project" "$prefix" pick_notifications
+    cloud_function_withdraw "$project" "$prefix" send_notification
+    cloud_function_withdraw "$project" "$prefix" spool_notifications
+    cloud_function_withdraw "$project" "$prefix" cache_urls
     cloud_function_withdraw "$project" \
-                            "${prefix}${cache_redirect_function_name}"
-    cloud_function_withdraw "$project" "${prefix}load_queue"
+                            "$prefix" "$cache_redirect_function_name"
+    cloud_function_withdraw "$project" "$prefix" load_queue
 }
 
 # Check if a scheduler job exists

--- a/cloud
+++ b/cloud
@@ -1502,7 +1502,7 @@ function cloud_functions_deploy() {
                           --memory 2048MB \
                           --max-instances=10 \
                           --timeout 540
-    
+
     cloud_function_deploy "$project" "${prefix}cache_urls" \
                           "$source" \
                           --entry-point kcidb_cache_urls \
@@ -1538,7 +1538,7 @@ function cloud_functions_deploy() {
 }
 
 # Withdraw Cloud Functions
-# Args: --project=NAME --prefix=PREFIX 
+# Args: --project=NAME --prefix=PREFIX
 #       --cache-redirect-function-name=NAME
 function cloud_functions_withdraw() {
     params="$(getopt_vars project prefix \


### PR DESCRIPTION
Add support for deploying and withdrawing specific Cloud Functions, so we could speed up develop/deploy/test loop.

Includes a bunch of requisite changes as well as a few minor somewhat-related improvements.