### PR TITLE
Actions: Mute updates in production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,6 +129,8 @@ jobs:
         run: |
           declare -a args=(
             kernelci-production "" 1
+            # Mute updates until we clear the queue
+            --mute-updates
             --extra-cc=kernelci-results-staging@groups.io
           )
           ./cloud deploy "${args[@]}" -v


### PR DESCRIPTION
The production deployment can't cope with the updates queue, the notification generation times out. This is possibly due to the PostgreSQL database being too big for the resources we have. Mute the updates until we reduce the database size by purging old data a little later.