### PR TITLE
Add timestamp indexes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,8 @@ jobs:
           ./cloud deploy "${args[@]}" -v
           KCIDB_DEPLOYMENT="This deployment is empty" \
             ./cloud shell  "${args[@]}" --heavy-asserts -- \
-                    pytest --tb=native --verbosity=2 --log-level=DEBUG
+                    pytest --tb=native --verbosity=2 --log-level=DEBUG \
+                           --durations=0 --durations-min=1
 
   deploy_to_production:
     needs: deploy_to_staging

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,9 @@ jobs:
         env:
           KCIDB_HOOKS: "pre-commit"
       - name: Test with pytest
-        run: KCIDB_IO_HEAVY_ASSERTS=1 KCIDB_HEAVY_ASSERTS=1 pytest --tb=native
+        run: |
+          KCIDB_IO_HEAVY_ASSERTS=1 KCIDB_HEAVY_ASSERTS=1 \
+            pytest --tb=native --durations=0 --durations-min=1
         env:
           KCIDB_HOOKS: "pre-commit"
 
@@ -172,7 +174,8 @@ jobs:
           ./cloud deploy "${env_args[@]}" --verbose &&
             KCIDB_DEPLOYMENT="This deployment is empty" \
               ./cloud shell  "${env_args[@]}" -- \
-                      pytest --tb=native --verbosity=2 --log-level=DEBUG ||
+                      pytest --tb=native --verbosity=2 --log-level=DEBUG \
+                             --durations=0 --durations-min=1 ||
               status=$((status || $?))
 
           ./cloud withdraw "${args[@]}" --verbose || status=$((status || $?))

--- a/kcidb/db/postgresql/__init__.py
+++ b/kcidb/db/postgresql/__init__.py
@@ -2,7 +2,7 @@
 
 import textwrap
 from kcidb.db.schematic import Driver as SchematicDriver
-from kcidb.db.postgresql.v04_02 import Schema as LatestSchema
+from kcidb.db.postgresql.v04_03 import Schema as LatestSchema
 
 
 class Driver(SchematicDriver):

--- a/kcidb/db/postgresql/schema.py
+++ b/kcidb/db/postgresql/schema.py
@@ -2,7 +2,8 @@
 Kernel CI PostgreSQL report database - misc schema definitions
 """
 import json
-from kcidb.db.sql.schema import Constraint, Column, Table as _SQLTable
+from kcidb.db.sql.schema import Constraint, Column, \
+    Table as _SQLTable, Index as _SQLIndex
 
 
 class BoolColumn(Column):
@@ -225,3 +226,22 @@ class Table(_SQLTable):
         """
         # TODO: Switch to hardcoding "_" key_sep in base class
         super().__init__("%s", columns, primary_key, key_sep="_")
+
+
+class Index(_SQLIndex):
+    """An index schema"""
+    def __init__(self, table, columns):
+        """
+        Initialize the index schema.
+
+        Args:
+            table:      The name of the table this index belongs to.
+            columns:    The list of names of table columns belonging to the
+                        index. The names consist of dot-separated parts, same
+                        as used for the Table creation parameters.
+        """
+        assert isinstance(table, str)
+        assert isinstance(columns, list)
+        assert all(isinstance(c, str) for c in columns)
+        # TODO: Switch to hardcoding "_" key_sep in base class
+        super().__init__(table, columns, key_sep="_")

--- a/kcidb/db/postgresql/v04_00.py
+++ b/kcidb/db/postgresql/v04_00.py
@@ -277,6 +277,9 @@ class Schema(AbstractSchema):
         name: Table(**args) for name, args in TABLES_ARGS.items()
     }
 
+    # A map of index names and schemas
+    INDEXES = {}
+
     # Queries and their columns for each type of raw object-oriented data.
     # Both should have columns in the same order.
     OO_QUERIES = dict(
@@ -518,6 +521,14 @@ class Schema(AbstractSchema):
                 except Exception as exc:
                     raise Exception(
                         f"Failed creating table {table_name!r}"
+                    ) from exc
+            # Create the indexes
+            for index_name, index_schema in self.INDEXES.items():
+                try:
+                    cursor.execute(index_schema.format_create(index_name))
+                except Exception as exc:
+                    raise Exception(
+                        f"Failed creating index {index_name!r}"
                     ) from exc
 
     def cleanup(self):

--- a/kcidb/db/postgresql/v04_00.py
+++ b/kcidb/db/postgresql/v04_00.py
@@ -483,13 +483,6 @@ class Schema(AbstractSchema):
         The database must be uninitialized.
         """
         with self.conn, self.conn.cursor() as cursor:
-            for table_name, table_schema in self.TABLES.items():
-                try:
-                    cursor.execute(table_schema.format_create(table_name))
-                except Exception as exc:
-                    raise Exception(
-                        f"Failed creating table {table_name!r}"
-                    ) from exc
             # Create the "first" and "last" aggregations
             # Source: https://wiki.postgresql.org/wiki/First/last_(aggregate)
             cursor.execute(textwrap.dedent("""\
@@ -518,6 +511,14 @@ class Schema(AbstractSchema):
                     PARALLEL = safe
                 )
             """))
+            # Create the tables
+            for table_name, table_schema in self.TABLES.items():
+                try:
+                    cursor.execute(table_schema.format_create(table_name))
+                except Exception as exc:
+                    raise Exception(
+                        f"Failed creating table {table_name!r}"
+                    ) from exc
 
     def cleanup(self):
         """

--- a/kcidb/db/postgresql/v04_03.py
+++ b/kcidb/db/postgresql/v04_03.py
@@ -1,0 +1,38 @@
+"""Kernel CI report database - PostgreSQL schema v4.3"""
+
+from kcidb.db.postgresql.schema import Index
+from .v04_02 import Schema as PreviousSchema
+
+
+class Schema(PreviousSchema):
+    """PostgreSQL database schema v4.3"""
+
+    # The schema's version.
+    version = (4, 3)
+
+    # A map of index names and schemas
+    INDEXES = {
+        f"{table}_{column}": Index(table, [column])
+        for table in PreviousSchema.TABLES
+        for column in ("_timestamp",)
+    }
+
+    @classmethod
+    def _inherit(cls, conn):
+        """
+        Inerit the database data from the previous schema version (if any).
+
+        Args:
+            conn:   Connection to the database to inherit. The database must
+                    comply with the previous version of the schema.
+        """
+        assert isinstance(conn, cls.Connection)
+        with conn, conn.cursor() as cursor:
+            for index_name, index_schema in cls.INDEXES.items():
+                if index_name not in PreviousSchema.INDEXES:
+                    try:
+                        cursor.execute(index_schema.format_create(index_name))
+                    except Exception as exc:
+                        raise Exception(
+                            f"Failed creating index {index_name!r}"
+                        ) from exc

--- a/kcidb/db/sql/schema.py
+++ b/kcidb/db/sql/schema.py
@@ -95,6 +95,28 @@ class TableColumn:
             return re.sub(r'(^|$|")', r'"\1', name)
         return '""'
 
+    @classmethod
+    def adapt_name(cls, name, key_sep):
+        """
+        Convert a dot-separated name to a quoted table column name (safe for
+        use in SQL statements), and the list of its keys, using the specified
+        "key" separator.
+
+        Args:
+            name:       The name of the column consisting of dot-separated
+                        parts ("keys").
+            key_sep:    String used to replace dots in column names ("key"
+                        separator)
+
+        Returns: The quoted name, and the list of name "keys".
+        """
+        assert isinstance(name, str)
+        assert isinstance(key_sep, str)
+        # Name parts (keys)
+        keys = name.split(".")
+        # Column name within the table, quoted for use in SQL statements
+        return cls.quote_name(key_sep.join(keys)), keys
+
     def __init__(self, name, schema, key_sep):
         """
         Initialize the table schema column.
@@ -109,10 +131,9 @@ class TableColumn:
         assert isinstance(name, str)
         assert isinstance(schema, Column)
         assert isinstance(key_sep, str)
-        # Name parts (keys)
-        self.keys = name.split(".")
-        # Column name within the table, quoted for use in SQL statements
-        self.name = self.quote_name(key_sep.join(self.keys))
+        # Column name within the table, quoted for use in SQL statements,
+        # and column name parts (keys)
+        self.name, self.keys = self.adapt_name(name, key_sep)
         # Column schema
         self.schema = schema
 

--- a/kcidb/db/sql/schema.py
+++ b/kcidb/db/sql/schema.py
@@ -412,3 +412,48 @@ class Table:
             yield self.unpack(obj,
                               with_metadata=with_metadata,
                               drop_null=drop_null)
+
+
+class Index:
+    """An index schema"""
+
+    # The type of table columns used in the index
+    TableColumn = TableColumn
+
+    def __init__(self, table, columns, key_sep="_"):
+        """
+        Initialize the index schema.
+
+        Args:
+            table:      The name of the table this index belongs to.
+            columns:    The list of names of table columns belonging to the
+                        index. The names consist of dot-separated parts, same
+                        as used for the Table creation parameters.
+            key_sep:    String used to replace dots in column names ("key"
+                        separator) when adapting them to the tables.
+        """
+        assert isinstance(table, str)
+        assert isinstance(columns, list)
+        assert all(isinstance(c, str) for c in columns)
+        self.table = table
+        # Dot-separated column names => quoted table column names
+        self.columns = {
+            name: self.TableColumn.adapt_name(name, key_sep)[0]
+            for name in columns
+        }
+
+    def format_create(self, name):
+        """
+        Format the "CREATE INDEX" command for the table.
+
+        Args:
+            name:       The name of the target index of the command.
+
+        Returns:
+            The formatted "CREATE INDEX" command.
+        """
+        return (
+            f"CREATE INDEX IF NOT EXISTS {name} ON {self.table} (" +
+            ", ".join(self.columns.values()) +
+            ")"
+        )


### PR DESCRIPTION
Add indexes on all _timestamp columns in a new v4.3 PostgreSQL schema, so that we can run queries to decide purging cut-off, in finite time, as well as speed up actual purges.