### PR TITLE
postgresql: fix get_version() for older PostgreSQL versions

### DIFF
--- a/kcidb/db/postgresql/v04_00.py
+++ b/kcidb/db/postgresql/v04_00.py
@@ -147,7 +147,7 @@ class Connection(AbstractConnection):
                     RETURNS integer
                     LANGUAGE SQL
                     IMMUTABLE
-                    RETURN %s
+                    AS 'SELECT %s'
                 """), (number, ))
 
     def get_schema_version(self):


### PR DESCRIPTION
The bare 'RETURN' statement in get_version() is caught as a syntax error by PostgreSQL 12.x. Return the integer literal using a simple SQL statement instead.

**NOTE**: Not tested with other PostgreSQL versions.