### PR TITLE
cache: Support downloading without Content-Length

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -79,7 +79,7 @@ def empty_deployment():
             pass
     # Remove contents from the cache bucket
     bucket_name = os.environ.get("KCIDB_CACHE_BUCKET_NAME")
-    client = kcidb.cache.Client(bucket_name, 0)
+    client = kcidb.cache.Client(bucket_name, 0, 0)
     client.empty()
 
 

--- a/main.py
+++ b/main.py
@@ -509,8 +509,10 @@ def get_cache_client():
     # It's alright, pylint: disable=global-statement
     global _CACHE_CLIENT
     if _CACHE_CLIENT is None:
+        chunk_size = 1024 * 1024
+        max_size = 5 * chunk_size
         _CACHE_CLIENT = kcidb.cache.Client(
-            CACHE_BUCKET_NAME, 5 * 1024 * 1024
+            CACHE_BUCKET_NAME, max_size, chunk_size
         )
     return _CACHE_CLIENT
 


### PR DESCRIPTION
Add support for caching URLs which don't include the Content-Length headers in their response. For now keep downloading fully into memory first, but download even without Content-Length until the limit is hit. Abort the caching if it is.

Update the test to verify the contents of the cached URLs, as now we're messing with it ourselves. Switch to using raw GitHub URLs as samples, as those don't change unless we change them ourselves.

This fixes the test which started failing because GitHub stopped supplying Content-Length on the URLs. This should now enable downloading artifacts from KernelCI and possibly others. Although we'll still be downloading only 1/256th of them.