### PR TITLE
doc/submitter_guide: prefix for `checkout_id`

### DIFF
--- a/doc/submitter_guide.md
+++ b/doc/submitter_guide.md
@@ -140,7 +140,7 @@ checkout with one build and one test, as well as one issue and one incident:
     "builds": [
         {
             "id": "submitter:32254",
-            "checkout_id": "c9c9735c46f589b9877b7fc00c89ef1b61a31e18",
+            "checkout_id": "submitter:c9c9735c46f589b9877b7fc00c89ef1b61a31e18",
             "origin": "submitter"
         }
     ],


### PR DESCRIPTION
As per the convention `checkout_id` value is expected to have `submitter:` prefix.
Update the example in the submitter guide accordingly.