### PR TITLE
tests.yaml: rename `kernelci_tast` test

### DIFF
--- a/tests.yaml
+++ b/tests.yaml
@@ -84,11 +84,6 @@ kernelci_sleep:
   home: https://github.com/kernelci/kernelci-core/blob/main/config/runtime/tests/sleep.jinja2
   description: |
     Runs sleep and wake-up checks for RTC enabled devices.
-kernelci_tast:
-  title: Tast test
-  home: https://github.com/kernelci/kernelci-core/blob/main/config/runtime/tests/tast.jinja2
-  description: |
-    Tast is ChromeOS-specific test suite that runs on Chromebooks.
 kselftest:
   title: Kernel self-tests
   home: https://kselftest.wiki.kernel.org/
@@ -298,6 +293,11 @@ stress-ng:
 syzkaller:
   title: syzkaller fuzzer
   home: https://github.com/google/syzkaller
+tast:
+  title: Tast test
+  home: https://chromium.googlesource.com/chromiumos/platform/tast/+/HEAD/README.md
+  description: |
+    Tast is ChromeOS-specific test suite that runs on Chromebooks.
 usex:
   title: UNIX System Exerciser (USEX)
   home: https://gitlab.com/cki-project/kernel-tests/-/tree/main/standards/usex


### PR DESCRIPTION
Rename `kernelci_tast` to `tast` as it is a known test suite from ChromeOS and not specific to KernelCI. Update test suite link as well.