### PR TITLE
tests.yaml: add `fluster` test

### DIFF
--- a/tests.yaml
+++ b/tests.yaml
@@ -67,6 +67,11 @@ dtbs_check:
 fio:
   title: Flexible I/O tester
   home: https://github.com/axboe/fio
+fluster:
+  title: Fluster test
+  home: https://github.com/fluendo/fluster
+  description: |
+    Fluster is a testing framework for decoder conformance.
 fwts:
   title: Firmware Test Suite
   home: https://wiki.ubuntu.com/FirmwareTestSuite/


### PR DESCRIPTION
Add Fluster, a testing framework for decoder conformance to the test catalogue.