### PR TITLE
Linux `stable-rc` subscription

### DIFF
--- a/kcidb/monitor/subscriptions/linux_stable_rc.py
+++ b/kcidb/monitor/subscriptions/linux_stable_rc.py
@@ -1,0 +1,32 @@
+"""Linux stable-rc subscription"""
+from datetime import (timezone, datetime, timedelta)
+
+from kcidb.monitor.output import NotificationMessage as Message
+
+
+def match_revision(revision):
+    """Match revisions of stable-rc tree"""
+    # Repo we're interested in
+    repo_url = "https://git.kernel.org/pub/scm/linux/kernel/git/stable/" \
+        "linux-stable-rc.git"
+
+    # If the revision is not from stable-rc repo,
+    # or there are no finished builds
+
+    if repo_url not in revision.repo_branch_checkouts:
+        return ()
+
+    if revision.builds_valid is None:
+        return ()
+
+    # Send notification 3 hours after a revision is created/updated
+    return (Message(
+        subject='KernelCI report for stable-rc: '
+                '{% include "stable_rc_revision_summary.txt.j2" %}',
+        to=["Jeny Sadadia <jeny.sadadia@collabora.com>",
+            "Gustavo Padovan <gustavo.padovan@collabora.com>",
+            "Shreeya Patel <shreeya.patel@collabora.com>"],
+        body='{% include "stable_rc_revision_description.txt.j2" %}',
+        cc=["KernelCI Results Staging <kernelci-results-staging@groups.io>"],
+        due=datetime.now(timezone.utc) + timedelta(hours=3)
+    ),)

--- a/kcidb/oo/__init__.py
+++ b/kcidb/oo/__init__.py
@@ -390,6 +390,22 @@ class Node(IncidentIssueBugContainer):
             waived_status_nodes[node.waived][node.status].append(node)
         return waived_status_nodes
 
+    @cached_property
+    def waived_status_tests(self):
+        """
+        A dictionary of all waived values and dictionaries of all status
+        values and lists of tests (test runs) with corresponding waived and
+        status values, for this and all child nodes, all in order of
+        decreasing priority.
+        """
+        waived_status_tests = {
+            waived: {status: [] for status in TEST_STATUS_PRIORITY}
+            for waived in TEST_WAIVED_PRIORITY
+        }
+        for test in self.tests:
+            waived_status_tests[test.waived][test.status].append(test)
+        return waived_status_tests
+
     def __getitem__(self, name):
         assert isinstance(name, (str, type(None)))
         return Node(self, name)

--- a/kcidb/templates/stable_rc_build.j2
+++ b/kcidb/templates/stable_rc_build.j2
@@ -1,0 +1,40 @@
+{# Build template macros #}
+
+{% macro build_stats(container) %}
+    {% if container.builds %}
+        {% set invalid_builds =
+                container.builds | selectattr("valid", "false") | list %}
+        {% set valid_builds =
+                container.builds | selectattr("valid", "true") | list %}
+        {% set invalid_build_count = invalid_builds | length %}
+        {% set valid_build_count = valid_builds | length %}
+        {{- valid_build_count | string + " passed, " +
+            invalid_build_count | string + " failed" }}
+    {% endif %}
+{% endmacro %}
+
+{% macro container_summary(container, max_list_len) %}
+    {% if container.builds %}
+        {{- "\nBUILDS" }}
+        {% set invalid_builds =
+                container.builds | selectattr("valid", "false") | list %}
+        {% set invalid_build_count = invalid_builds | length %}
+        {% if invalid_builds %}
+            {{- "\n    Failures" }}
+            {% for origin, builds in invalid_builds|groupby("origin") %}
+                {% for build in builds %}
+                    {{- "       -"+  build.architecture + " (" + build.config_name + ")" }}
+                    {{- "\n       Build detail: https://kcidb.kernelci.org/d/build/build?orgId=1&var-id=" + build.id}}
+                    {% if build.log_excerpt %}
+                        {{- "       Build error: " + build.log_error }}
+                    {% endif %}
+                {% endfor %}
+                {{- "       CI system: " + origin + "\n\n"-}}
+            {% endfor %}
+        {% else %}
+            {{- "\n    No build failures found" }}
+        {% endif %}
+    {% else %}
+        {{- "\n    No builds found" }}
+    {% endif %}
+{% endmacro %}

--- a/kcidb/templates/stable_rc_revision.j2
+++ b/kcidb/templates/stable_rc_revision.j2
@@ -1,0 +1,34 @@
+{# Revision template macros #}
+
+{% macro summary(revision) %}
+    {% set git_repository_url =
+        revision.repo_branch_checkouts | list | first %}
+    {% set git_repository_branch =
+        revision.repo_branch_checkouts[git_repository_url] | list | first %}
+    {% set location = none
+                      if git_repository_url is none
+                      else (git_repository_branch |
+                            reject("none") | join("")) %}
+    {% set commit = (none
+                     if revision.git_commit_hash is none
+                     else revision.git_commit_hash[:12])
+                    if revision.git_commit_name is none
+                    else revision.git_commit_name %}
+    {% set location_commit = [location, commit] | reject("none") |
+                             join("@") | default(none, true) %}
+    {% set patches = ("+" + (revision.patchset_files | length | string) + "P")
+                     if revision.patchset_files
+                     else none %}
+    {% set location_commit_patches =
+        none
+        if location_commit is none
+        else ([location_commit, patches] | reject("none") | join("")) %}
+    {% set comment =
+        revision.repo_branch_checkouts[git_repository_url]
+                                      [git_repository_branch] |
+        map(attribute="comment") | reject("none") | first | default(none)
+    %}
+    {{- [location_commit_patches,
+         none if comment is none else ('"' + comment + '"')] |
+        reject("none") | join(" ") -}}
+{% endmacro %}

--- a/kcidb/templates/stable_rc_revision_description.txt.j2
+++ b/kcidb/templates/stable_rc_revision_description.txt.j2
@@ -1,0 +1,65 @@
+{# Revision description template #}
+{% import "stable_rc_test.j2" as test_macros %}
+{% import "stable_rc_build.j2" as build_macros %}
+{% import "misc.j2" as misc_macros %}
+{# Maximum length of a list of things (builds/tests/etc.) #}
+{% set max_list_len = 5 %}
+
+OVERVIEW
+
+{% if revision.patchset_files %}
+       Patches: {{ misc_macros.valid_badge(revision.checkouts_valid) }}
+{% endif %}
+{% if revision.builds %}
+        Builds: {{ build_macros.build_stats(revision) }}
+{% endif %}
+{% if revision.tests %}
+         Tests: {{ test_macros.tests_stats(revision) }}
+{% endif %}
+    CI systems: {{ revision.checkouts | map(attribute="origin") |
+           unique | sort | join(", ") }}
+
+REVISION
+
+    Commit
+        {% if revision.git_commit_name %}
+            {{- "        name: " + revision.git_commit_name }}
+        {% endif %}
+        {% if revision.git_commit_hash %}
+            {{- "        hash: " + revision.git_commit_hash }}
+        {% endif %}
+    Checked out from
+        {% for repo, branch_checkouts
+           in revision.repo_branch_checkouts.items() %}
+            {{- "        " +
+                (([repo] + (branch_checkouts | list)) |
+                 reject("none") | join(" ")) }}
+        {% endfor %}
+{% if revision.patchset_files %}
+    {% set patch_count = revision.patchset_files | length %}
+    With {{ patch_count -}}
+    {{- " patches" if patch_count > 1 else "patch" }} applied
+        {% for patchset_file in revision.patchset_files[:max_list_len] %}
+            {{- "        " + patchset_file.url }}
+        {% endfor %}
+        {% if (revision.patchset_files | length) > max_list_len %}
+            {{- "        ..." }}
+        {% endif %}
+{% endif %}
+
+{# #}
+{{- build_macros.container_summary(revision, max_list_len) -}}
+{{- test_macros.container_summary(revision, max_list_len) -}}
+{# #}
+
+See complete and up-to-date report at:
+
+    https://kcidb.kernelci.org/d/revision/revision?orgId=1&var-git_commit_hash={{revision.git_commit_hash | urlencode }}&var-patchset_hash={{revision.patchset_hash | urlencode }}
+
+
+Tested-by: kernelci.org bot <bot@kernelci.org>
+
+Thanks,
+KernelCI team
+
+{# Force git commit hook to ignore trailing newline #}

--- a/kcidb/templates/stable_rc_revision_summary.txt.j2
+++ b/kcidb/templates/stable_rc_revision_summary.txt.j2
@@ -1,0 +1,3 @@
+{# Revision (single-line) summary template #}
+{% import "stable_rc_revision.j2" as revision_macros %}
+{{- revision_macros.summary(revision) -}}

--- a/kcidb/templates/stable_rc_test.j2
+++ b/kcidb/templates/stable_rc_test.j2
@@ -1,0 +1,37 @@
+{# Test macros #}
+
+{% macro tests_stats(container) %}
+    {% if container.tests %}
+        {% set waived_status_nodes = container.tests_root.waived_status_nodes %}
+        {% set failed_nodes = waived_status_nodes[false]["FAIL"] %}
+        {% set passed_nodes = waived_status_nodes[false]["PASS"] %}
+        {{- passed_nodes | length | string + " passed, " +
+            failed_nodes | length | string + " failed" }}
+    {% endif %}
+{% endmacro %}
+
+{% macro container_summary(container, max_list_len) %}
+    {{- "\nBOOT TESTS" }}
+    {% if container.tests %}
+        {% set failed_boot_tests = container.tests_root["boot"].waived_status_tests[false]["FAIL"] %}
+        {% if failed_boot_tests %}
+            {{- "\n    Failures" }}
+            {% for origin, boot_tests in failed_boot_tests|groupby("origin") %}
+                {% for architecture, tests in boot_tests|groupby("build.architecture") %}
+                    {% set device_list = tests | selectattr('misc.platform', 'defined') | list %}
+                    {% if device_list %}
+                        {{- "      " + architecture }}:({{ tests|map(attribute="build.config_name") | unique | join("") }})
+                    {% endif %}
+                    {% for device in device_list %}
+                        {{- "      -" + device.misc.platform }}
+                    {% endfor %}
+                {% endfor %}
+                {{- "      CI system: " + origin + "\n" }}
+            {% endfor %}
+        {% else %}
+            {{- "\n    No boot failures found" }}
+        {% endif %}
+    {% else %}
+        {{- "\n    No tests found" }}
+    {% endif %}
+{% endmacro %}

--- a/kcidb/test_monitor.py
+++ b/kcidb/test_monitor.py
@@ -843,3 +843,113 @@ def test_email_generated(empty_deployment):
         # Check we get no more notification messages
         assert len(email_subscriber.pull(1, 5)) == 0, \
             f"Extra emails for {io_version!r}"
+
+
+def test_linux_stable_rc():
+    """Check stable-rc subscription works"""
+    notifications = match(
+        {
+            "version": {
+                "major": 4,
+                "minor": 3
+            },
+            "checkouts": [
+                {
+                    "id": "maestro:66969be5aa07c494f8d22863",
+                    "origin": "maestro",
+                    "tree_name": "stable-rc",
+                    "git_repository_url": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git",
+                    "git_commit_hash": "51945679d212aae61a418eff41370c13da94f94d",
+                    "git_repository_branch": "linux-5.4.y",
+                    "git_commit_name": "v5.4.279-79-g51945679d212",
+                    "patchset_files": [],
+                    "patchset_hash": "",
+                    "start_time": "2024-07-16T16:12:21.683+00:00",
+                    "contacts": [],
+                    "valid": True
+                },
+                {
+                    "id": "tuxsuite:51945679d212aae61a418eff41370c13da94f94d",
+                    "origin": "tuxsuite",
+                    "git_repository_url": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git",
+                    "git_commit_hash": "51945679d212aae61a418eff41370c13da94f94d",
+                    "git_commit_name": "v5.4.279-79-g51945679d212",
+                    "patchset_files": [],
+                    "patchset_hash": "",
+                    "start_time": "2024-07-16T16:15:56+00:00",
+                    "contacts": [],
+                    "valid": True
+                }
+            ],
+            "builds": [
+                {
+                    "id": "maestro:66969c63aa07c494f8d22ad8",
+                    "checkout_id": "maestro:66969be5aa07c494f8d22863",
+                    "origin": "maestro",
+                    "comment": "v5.4.279-79-g51945679d212",
+                    "start_time": "2024-07-16T16:14:27.761+00:00",
+                    "architecture": "arm64",
+                    "config_name": "cros://chromeos-5.4/arm64/chromiumos-qualcomm.flavour.config",
+                    "valid": False,
+                    "log_excerpt": "./arch/arm64/include/asm/memory.h: " \
+                        "In function ‘__tag_set’:\n" \
+                        "./arch/arm64/include/asm/memory.h:238:22: warning: cast from "\
+                        "pointer to integer of different size [-Wpointer-to-int-cast]\n" \
+                        "238 | u64 __addr = (u64)addr & ~__tag_shifted(0xff);\n" \
+                        "| ^\n" \
+                        "/tmp/ccFJEFDb.s: Assembler messages:\n" \
+                        "/tmp/ccFJEFDb.s:129: Error: invalid barrier type -- `dmb ishld'\n" \
+                        "/tmp/ccFJEFDb.s:234: Error: invalid barrier type -- `dmb ishld'\n" \
+                        "/tmp/ccFJEFDb.s:510: Error: invalid barrier type -- `dmb ishld'\n" \
+                        "/tmp/ccFJEFDb.s:537: Error: invalid barrier type -- `dmb ishld'\n" \
+                        "/tmp/ccFJEFDb.s:1132: Error: invalid barrier type -- `dmb ishld'\n" \
+                        "/tmp/ccFJEFDb.s:1216: Error: invalid barrier type -- `dmb ishld'\n" \
+                        "make[1]: *** [arch/arm64/kernel/vdso32/Makefile:166: " \
+                        "arch/arm64/kernel/vdso32/vgettimeofday.o] Error 1\n" \
+                        "make: *** [arch/arm64/Makefile:170: vdso_prepare] Error 2"
+                },
+                {
+                    "id": "tuxsuite:2jKrMEMuY667cDnJgLrHdpnjxvS",
+                    "checkout_id": "tuxsuite:51945679d212aae61a418eff41370c13da94f94d",
+                    "origin": "tuxsuite",
+                    "start_time": "2024-07-16T16:15:59+00:00",
+                    "architecture": "s390",
+                    "config_name": "defconfig",
+                    "valid": False
+                },
+                {
+                    "id": "maestro:66969c5faa07c494f8d22ac1",
+                    "checkout_id": "maestro:66969be5aa07c494f8d22863",
+                    "origin": "maestro",
+                    "comment": "v5.4.279-79-g51945679d212",
+                    "start_time": "2024-07-16T16:14:23.836+00:00",
+                    "architecture": "x86_64",
+                    "config_name": "x86_64_defconfig",
+                    "valid": True
+                }
+            ],
+            "tests": [
+                {
+                    "id": "maestro:6696c76faa07c494f8d2828c",
+                    "build_id": "maestro:66969c5faa07c494f8d22ac1",
+                    "origin": "maestro",
+                    "path": "boot",
+                    "comment": "baseline-x86-intel on acer-cbv514-1h-34uz-brya in lava-collabora",
+                    "status": "FAIL",
+                    "waived": False,
+                    "start_time": "2024-07-16T19:18:07.209+00:00",
+                    "misc": {"platform": "acer-cbv514-1h-34uz-brya"}
+                }
+            ]
+        }
+    )
+
+    subjects = sorted([
+        n.message.subject
+        for n in notifications
+        if n.subscription == "linux_stable_rc" and
+            "Jeny Sadadia <jeny.sadadia@collabora.com>" in n.message.to
+    ])
+
+    assert len(subjects) == 1
+    assert re.match(r"^KernelCI report for stable-rc: ", subjects[0])


### PR DESCRIPTION
Closes https://github.com/kernelci/kcidb/issues/532

Add a subscription script for generating notifications for Linux `stable-rc` tree. Also, add a test method to `kcidb/test_monitor.py` for the same.