### PR TITLE
cloud: Load submissions into PostgreSQL only, faster

### DIFF
--- a/cloud
+++ b/cloud
@@ -217,14 +217,7 @@ function execute_command() {
     fi
     declare -a -r bigquery_args
 
-    declare -r database=$(
-        echo -n "mux: "
-        echo -n "$psql_kcidb_db" | escape_whitespace
-        echo -n " "
-        echo -n "$bigquery_kcidb_db" | escape_whitespace
-        echo -n " "
-        echo -n "$bigquery_sample_kcidb_db" | escape_whitespace
-    )
+    declare -r database="$psql_kcidb_db"
 
     if "$test"; then
         declare -r sqlite_clean_test_file="$TMPDIR/clean.sqlite3"

--- a/kcidb/cloud/functions.sh
+++ b/kcidb/cloud/functions.sh
@@ -228,7 +228,7 @@ function functions_deploy() {
                     --env-vars-file "$env_yaml_file" \
                     --trigger-topic "${load_queue_trigger_topic}" \
                     --memory 1024MB \
-                    --max-instances=1 \
+                    --max-instances=4 \
                     --timeout 540
     # Remove the environment YAML file
     rm "$env_yaml_file"


### PR DESCRIPTION
Remove loading submissions into BigQuery until we come up with a way to increase throughput (likely pulling chunks from PostgreSQL). This should help us deal with the backlog in production submission queue.

We might also need to either switch to direct triggering of Cloud Functions by messages from the queue, to reduce latency, or simply switch to a persistent Cloud Run service.

Concerns: https://github.com/kernelci/kcidb/issues/541