### PR TITLE
Fix `stable-rc` report

### DIFF
--- a/kcidb/templates/stable_rc.j2
+++ b/kcidb/templates/stable_rc.j2
@@ -1,0 +1,2 @@
+{# stable-rc macros #}
+{% set selected_origins = ['maestro', 'broonie'] %}

--- a/kcidb/templates/stable_rc_build.j2
+++ b/kcidb/templates/stable_rc_build.j2
@@ -23,7 +23,9 @@
             {{- "\n    Failures" }}
             {% for origin, builds in invalid_builds|groupby("origin") %}
                 {% for build in builds %}
-                    {{- "       -"+  build.architecture + " (" + build.config_name + ")" }}
+                    {{- [('       -') + build.architecture,
+                        none if build.config_name is none else ('(' + build.config_name + ')')] |
+                        reject("none") | join(" ") -}}
                     {{- "\n       Build detail: https://kcidb.kernelci.org/d/build/build?orgId=1&var-id=" + build.id}}
                     {% if build.log_excerpt %}
                         {{- "       Build error: " + build.log_error }}

--- a/kcidb/templates/stable_rc_build.j2
+++ b/kcidb/templates/stable_rc_build.j2
@@ -1,11 +1,14 @@
 {# Build template macros #}
+{% import "stable_rc.j2" as stable_rc_macros %}
 
 {% macro build_stats(container) %}
     {% if container.builds %}
         {% set invalid_builds =
-                container.builds | selectattr("valid", "false") | list %}
+                container.builds | selectattr("valid", "false") |
+                selectattr('origin', 'in', stable_rc_macros.selected_origins) | list %}
         {% set valid_builds =
-                container.builds | selectattr("valid", "true") | list %}
+                container.builds | selectattr("valid", "true") |
+                selectattr('origin', 'in', stable_rc_macros.selected_origins) | list %}
         {% set invalid_build_count = invalid_builds | length %}
         {% set valid_build_count = valid_builds | length %}
         {{- valid_build_count | string + " passed, " +
@@ -22,18 +25,20 @@
         {% if invalid_builds %}
             {{- "\n    Failures" }}
             {% for origin, builds in invalid_builds|groupby("origin") %}
-                {% for build in builds %}
-                    {% if build.architecture %}
-                        {{- [('       -') + build.architecture,
-                            none if build.config_name is none else ('(' + build.config_name + ')')] |
-                            reject("none") | join(" ") -}}
-                        {{- "\n       Build detail: https://kcidb.kernelci.org/d/build/build?orgId=1&var-id=" + build.id}}
-                        {% if build.log_excerpt %}
-                            {{- "       Build error: " + build.log_error }}
+                {% if origin in stable_rc_macros.selected_origins %}
+                    {% for build in builds %}
+                        {% if build.architecture %}
+                            {{- [('       -') + build.architecture,
+                                none if build.config_name is none else ('(' + build.config_name + ')')] |
+                                reject("none") | join(" ") -}}
+                            {{- "\n       Build detail: https://kcidb.kernelci.org/d/build/build?orgId=1&var-id=" + build.id}}
+                            {% if build.log_excerpt %}
+                                {{- "       Build error: " + build.log_error }}
+                            {% endif %}
                         {% endif %}
-                    {% endif %}
-                {% endfor %}
-                {{- "       CI system: " + origin + "\n\n"-}}
+                    {% endfor %}
+                    {{- "       CI system: " + origin + "\n\n"-}}
+                {% endif %}
             {% endfor %}
         {% else %}
             {{- "\n    No build failures found" }}

--- a/kcidb/templates/stable_rc_build.j2
+++ b/kcidb/templates/stable_rc_build.j2
@@ -23,12 +23,14 @@
             {{- "\n    Failures" }}
             {% for origin, builds in invalid_builds|groupby("origin") %}
                 {% for build in builds %}
-                    {{- [('       -') + build.architecture,
-                        none if build.config_name is none else ('(' + build.config_name + ')')] |
-                        reject("none") | join(" ") -}}
-                    {{- "\n       Build detail: https://kcidb.kernelci.org/d/build/build?orgId=1&var-id=" + build.id}}
-                    {% if build.log_excerpt %}
-                        {{- "       Build error: " + build.log_error }}
+                    {% if build.architecture %}
+                        {{- [('       -') + build.architecture,
+                            none if build.config_name is none else ('(' + build.config_name + ')')] |
+                            reject("none") | join(" ") -}}
+                        {{- "\n       Build detail: https://kcidb.kernelci.org/d/build/build?orgId=1&var-id=" + build.id}}
+                        {% if build.log_excerpt %}
+                            {{- "       Build error: " + build.log_error }}
+                        {% endif %}
                     {% endif %}
                 {% endfor %}
                 {{- "       CI system: " + origin + "\n\n"-}}

--- a/kcidb/templates/stable_rc_revision_description.txt.j2
+++ b/kcidb/templates/stable_rc_revision_description.txt.j2
@@ -14,7 +14,7 @@ OVERVIEW
         Builds: {{ build_macros.build_stats(revision) }}
 {% endif %}
 {% if revision.tests %}
-         Tests: {{ test_macros.tests_stats(revision) }}
+    Boot tests: {{ test_macros.tests_stats(revision) }}
 {% endif %}
     CI systems: {{ revision.checkouts | map(attribute="origin") |
            unique | sort | join(", ") }}

--- a/kcidb/templates/stable_rc_revision_description.txt.j2
+++ b/kcidb/templates/stable_rc_revision_description.txt.j2
@@ -1,4 +1,5 @@
 {# Revision description template #}
+{% import "stable_rc.j2" as stable_rc_macros %}
 {% import "stable_rc_test.j2" as test_macros %}
 {% import "stable_rc_build.j2" as build_macros %}
 {% import "misc.j2" as misc_macros %}
@@ -17,7 +18,7 @@ OVERVIEW
     Boot tests: {{ test_macros.tests_stats(revision) }}
 {% endif %}
     CI systems: {{ revision.checkouts | map(attribute="origin") |
-           unique | sort | join(", ") }}
+           unique | sort | select('in', stable_rc_macros.selected_origins) | join(", ") }}
 
 REVISION
 

--- a/kcidb/templates/stable_rc_revision_description.txt.j2
+++ b/kcidb/templates/stable_rc_revision_description.txt.j2
@@ -29,13 +29,26 @@ REVISION
         {% if revision.git_commit_hash %}
             {{- "        hash: " + revision.git_commit_hash }}
         {% endif %}
+    {# The stable-rc repo's URL #}
+    {% set stable_rc_repo = 'https://git.kernel.org/pub/scm/linux/' +
+                            'kernel/git/stable/linux-stable-rc.git' %}
+    {# List of other repo's URLs #}
+    {% set other_repos = revision.repo_branch_checkouts.keys() |
+                         reject('==', stable_rc_repo) | list %}
     Checked out from
-        {% for repo, branch_checkouts
-           in revision.repo_branch_checkouts.items() %}
-            {{- "        " +
-                (([repo] + (branch_checkouts | list)) |
-                 reject("none") | join(" ")) }}
+        {{- "\n        " +
+            (([stable_rc_repo] + (revision.repo_branch_checkouts[stable_rc_repo] | list)) |
+            reject("none") | join(" ")) }}
+    {% if other_repos %}
+    Also checked out from
+        {% for repo, branch_checkouts in revision.repo_branch_checkouts.items() %}
+            {% if repo in other_repos %}
+                {{- "        " +
+                    (([repo] + (branch_checkouts | list)) |
+                    reject("none") | join(" ")) }}
+            {% endif %}
         {% endfor %}
+    {% endif %}
 {% if revision.patchset_files %}
     {% set patch_count = revision.patchset_files | length %}
     With {{ patch_count -}}

--- a/kcidb/templates/stable_rc_test.j2
+++ b/kcidb/templates/stable_rc_test.j2
@@ -2,11 +2,11 @@
 
 {% macro tests_stats(container) %}
     {% if container.tests %}
-        {% set waived_status_nodes = container.tests_root.waived_status_nodes %}
-        {% set failed_nodes = waived_status_nodes[false]["FAIL"] %}
-        {% set passed_nodes = waived_status_nodes[false]["PASS"] %}
-        {{- passed_nodes | length | string + " passed, " +
-            failed_nodes | length | string + " failed" }}
+        {% set boot_tests = container.tests_root["boot"].waived_status_tests %}
+        {% set failed_tests = boot_tests[false]["FAIL"] %}
+        {% set passed_tests = boot_tests[false]["PASS"] %}
+        {{- passed_tests | length | string + " passed, " +
+            failed_tests | length | string + " failed" }}
     {% endif %}
 {% endmacro %}
 

--- a/kcidb/templates/stable_rc_test.j2
+++ b/kcidb/templates/stable_rc_test.j2
@@ -1,10 +1,11 @@
 {# Test macros #}
+{% import "stable_rc.j2" as stable_rc_macros %}
 
 {% macro tests_stats(container) %}
     {% if container.tests %}
         {% set boot_tests = container.tests_root["boot"].waived_status_tests %}
-        {% set failed_tests = boot_tests[false]["FAIL"] %}
-        {% set passed_tests = boot_tests[false]["PASS"] %}
+        {% set failed_tests = boot_tests[false]["FAIL"] | selectattr('origin', 'in', stable_rc_macros.selected_origins) | list %}
+        {% set passed_tests = boot_tests[false]["PASS"] | selectattr('origin', 'in', stable_rc_macros.selected_origins) | list %}
         {{- passed_tests | length | string + " passed, " +
             failed_tests | length | string + " failed" }}
     {% endif %}
@@ -17,16 +18,18 @@
         {% if failed_boot_tests %}
             {{- "\n    Failures" }}
             {% for origin, boot_tests in failed_boot_tests|groupby("origin") %}
-                {% for architecture, tests in boot_tests|groupby("build.architecture") %}
-                    {% set device_list = tests | selectattr('misc.platform', 'defined') | list %}
-                    {% if device_list %}
-                        {{- "      " + architecture }}:({{ tests|map(attribute="build.config_name") | unique | join("") }})
-                    {% endif %}
-                    {% for device in device_list %}
-                        {{- "      -" + device.misc.platform }}
+                {% if origin in stable_rc_macros.selected_origins %}
+                    {% for architecture, tests in boot_tests|groupby("build.architecture") %}
+                        {% set device_list = tests | selectattr('misc.platform', 'defined') | list %}
+                        {% if device_list %}
+                            {{- "      " + architecture }}:({{ tests|map(attribute="build.config_name") | unique | join("") }})
+                        {% endif %}
+                        {% for device in device_list %}
+                            {{- "      -" + device.misc.platform }}
+                        {% endfor %}
                     {% endfor %}
-                {% endfor %}
-                {{- "      CI system: " + origin + "\n" }}
+                    {{- "      CI system: " + origin + "\n" }}
+                {% endif %}
             {% endfor %}
         {% else %}
             {{- "\n    No boot failures found" }}


### PR DESCRIPTION
- Fix boot tests overview
- Handle missing build architecture and config for build failure summary
- Only take into account results from `maestro` and `broonie` CI systems as of now
-  Add `Also checked out from` tag in `REVISION` section to list checkout URL with the same commit from trees other than `stable-rc`