### PR TITLE
stable-rc: fix empty `BOOT TESTS` section

### DIFF
--- a/kcidb/templates/stable_rc_test.j2
+++ b/kcidb/templates/stable_rc_test.j2
@@ -14,21 +14,23 @@
 {% macro container_summary(container, max_list_len) %}
     {{- "\nBOOT TESTS" }}
     {% if container.tests %}
-        {% set failed_boot_tests = container.tests_root["boot"].waived_status_tests[false]["FAIL"] %}
+        {% set failed_boot_tests = container.tests_root["boot"].waived_status_tests[false]["FAIL"] |
+            selectattr('origin', 'in', stable_rc_macros.selected_origins) | list %}
         {% if failed_boot_tests %}
             {{- "\n    Failures" }}
             {% for origin, boot_tests in failed_boot_tests|groupby("origin") %}
-                {% if origin in stable_rc_macros.selected_origins %}
-                    {% for architecture, tests in boot_tests|groupby("build.architecture") %}
-                        {% set device_list = tests | selectattr('misc.platform', 'defined') | list %}
-                        {% if device_list %}
-                            {{- "      " + architecture }}:({{ tests|map(attribute="build.config_name") | unique | join("") }})
-                        {% endif %}
-                        {% for device in device_list %}
-                            {{- "      -" + device.misc.platform }}
+                {% set boot_tests_info = boot_tests | selectattr('environment_misc.platform', 'defined') | list %}
+                {% if boot_tests_info %}
+                    {% for architecture, tests in boot_tests_info|groupby("build.architecture") %}
+                        {{- "      " + architecture }}:({{ tests|map(attribute="build.config_name") | unique | join("") }})
+                        {% for test in tests %}
+                            {{- "      -" + test.environment_misc.platform }}
                         {% endfor %}
                     {% endfor %}
                     {{- "      CI system: " + origin + "\n" }}
+                {% else %}
+                    {{- "\n      Missing failure information. Sorry, we are working on improving report for this situation." }}
+                    {{- "\n      CI system: " + origin + "\n" }}
                 {% endif %}
             {% endfor %}
         {% else %}


### PR DESCRIPTION
Fix an issue of empty section for boot failures. This was due to the use of an incorrect test node field for getting `platform` information.
Use `environment.misc.platform` to fix the issue.
Also, display the below message when boot failures are found without failure information:
```
Boot failures found but failure information missing
```

So, now the boot failures would look like:
```
BOOT TESTS

    Failures

      Boot failures found but failure information missing
      CI system: broonie

      x86_64:(x86_64_defconfig)
      -acer-cbv514-1h-34uz-brya
      CI system: maestro

```