### PR TITLE
stable-rc: fix other repo list

### DIFF
--- a/kcidb/templates/stable_rc_revision_description.txt.j2
+++ b/kcidb/templates/stable_rc_revision_description.txt.j2
@@ -34,7 +34,7 @@ REVISION
                             'kernel/git/stable/linux-stable-rc.git' %}
     {# List of other repo's URLs #}
     {% set other_repos = revision.repo_branch_checkouts.keys() |
-                         reject('==', stable_rc_repo) | list %}
+                         reject('==', stable_rc_repo) | reject("none") | list %}
     Checked out from
         {{- "\n        " +
             (([stable_rc_repo] + (revision.repo_branch_checkouts[stable_rc_repo] | list)) |


### PR DESCRIPTION
Fix list displayed in `Also checked out from` for checkout without git repository URL.
Such as:
https://kcidb.kernelci.org/d/checkout/checkout?orgId=1&var-datasource=production&var-origin=All&var-build_architecture=All&var-build_config_name=All&var-id=broonie:1e7748be65d242138e8bf9f2ca2d7a07