### PR TITLE
stable-rc: fix `BOOT TESTS` section

### DIFF
--- a/kcidb/templates/stable_rc_test.j2
+++ b/kcidb/templates/stable_rc_test.j2
@@ -19,7 +19,8 @@
         {% if failed_boot_tests %}
             {{- "\n    Failures" }}
             {% for origin, boot_tests in failed_boot_tests|groupby("origin") %}
-                {% set boot_tests_info = boot_tests | selectattr('environment_misc.platform', 'defined') | list %}
+                {% set boot_tests_info = boot_tests | selectattr('environment_misc.platform', 'defined') |
+                selectattr('build.architecture', 'ne', None) | list %}
                 {% if boot_tests_info %}
                     {% for architecture, tests in boot_tests_info|groupby("build.architecture") %}
                         {{- "      " + architecture }}:({{ tests|map(attribute="build.config_name") | unique | join("") }})


### PR DESCRIPTION
Fix the below error while displaying boot failures when related build architecture information not found:
```
File "/workspace/kcidb/templates/stable_rc_test.j2", line 22, in template
    {% for architecture, tests in boot_tests|groupby("build.architecture") %}
  File "/layers/google.python.pip/pip/lib/python3.9/site-packages/jinja2/async_utils.py", line 45, in wrapper
    return normal_func(*args, **kwargs)
  File "/layers/google.python.pip/pip/lib/python3.9/site-packages/jinja2/filters.py", line 1261, in sync_do_groupby
    for key, values in groupby(sorted(value, key=expr), expr)
TypeError: '<' not supported between instances of 'str' and 'NoneType
```