### PR TITLE
kcidb/oo: remove a build error pattern

### DIFF
--- a/kcidb/oo/__init__.py
+++ b/kcidb/oo/__init__.py
@@ -610,7 +610,6 @@ class Build(Object, TestContainer,
             r'\.h:.*error',
             r'error.*modpost',
             'No rule to make target',
-            'tail will be killed now',
             'No such file',
         ]
 


### PR DESCRIPTION
The below build log isn't an actual error message: `Build script is completed, tail will be killed now`. Hence, remove the related pattern from the list of build errors.