### PR TITLE
stable-rc: fix empty builds failures section

### DIFF
--- a/kcidb/templates/stable_rc_build.j2
+++ b/kcidb/templates/stable_rc_build.j2
@@ -20,7 +20,8 @@
     {% if container.builds %}
         {{- "\nBUILDS" }}
         {% set invalid_builds =
-                container.builds | selectattr("valid", "false") | list %}
+                container.builds | selectattr("valid", "false") |
+                selectattr('origin', 'in', stable_rc_macros.selected_origins) | list %}
         {% set invalid_build_count = invalid_builds | length %}
         {% if invalid_builds %}
             {{- "\n    Failures" }}


### PR DESCRIPTION
Fix empty builds section like the below:
```
BUILDS

    Failures
```