### PR TITLE
Tune notification spooling

### DIFF
--- a/kcidb/cloud/functions.sh
+++ b/kcidb/cloud/functions.sh
@@ -202,8 +202,8 @@ function functions_deploy() {
                     spool_notifications \
                     --env-vars-file "$env_yaml_file" \
                     --trigger-topic "${updated_topic}" \
-                    --memory 2048MB \
-                    --max-instances=5 \
+                    --memory 4096MB \
+                    --max-instances=2 \
                     --timeout 540
 
     function_deploy "$sections" "$source" "$project" "$prefix" \

--- a/kcidb/cloud/psql.sh
+++ b/kcidb/cloud/psql.sh
@@ -90,6 +90,7 @@ function psql_instance_deploy() {
             --region="$PSQL_INSTANCE_REGION" \
             --tier="$PSQL_INSTANCE_TIER" \
             --assign-ip \
+            --storage-type=SSD \
             --no-storage-auto-increase \
             --database-flags=cloudsql.iam_authentication=on \
             --root-password="$(password_get psql_superuser)" \

--- a/kcidb/cloud/psql.sh
+++ b/kcidb/cloud/psql.sh
@@ -294,6 +294,7 @@ function _psql_database_setup() {
         \\set ON_ERROR_STOP on
 
         GRANT USAGE ON SCHEMA public TO $editor, $viewer;
+        REVOKE CREATE ON SCHEMA public FROM PUBLIC;
 
         ALTER DEFAULT PRIVILEGES IN SCHEMA public
         GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO $editor;

--- a/kcidb/cloud/psql.sh
+++ b/kcidb/cloud/psql.sh
@@ -79,6 +79,10 @@ function psql_instance_deploy() {
 
     exists=$(psql_instance_exists "$project" "$name")
     if ! "$exists"; then
+        declare -r -a database_flags=(
+            cloudsql.iam_authentication=on
+            max_connections=200
+        )
         # Get and cache the password in the current shell first
         password_get psql_superuser >/dev/null
         # Create the instance with the cached password
@@ -92,9 +96,9 @@ function psql_instance_deploy() {
             --assign-ip \
             --storage-type=SSD \
             --no-storage-auto-increase \
-            --database-flags=cloudsql.iam_authentication=on \
             --root-password="$(password_get psql_superuser)" \
-            --database-version=POSTGRES_14
+            --database-version=POSTGRES_14 \
+            --database-flags="$(IFS=','; echo "${database_flags[*]}")"
     fi
 
     # Deploy the shared viewer user

--- a/kcidb/cloud/psql.sh
+++ b/kcidb/cloud/psql.sh
@@ -82,6 +82,7 @@ function psql_instance_deploy() {
         declare -r -a database_flags=(
             cloudsql.iam_authentication=on
             max_connections=200
+            random_page_cost=1.5
         )
         # Get and cache the password in the current shell first
         password_get psql_superuser >/dev/null


### PR DESCRIPTION
Reduce the instances of notification-spooling Cloud Functions to just two to reduce the load on PostgreSQL, and double their memory, as they're hitting the current limit quite often now.

Revoke the default permission to create object in the public schema of each KCIDB database in PostgreSQL. That permission is granted per-user, and the default was overlooked until recently.

Supply the currently-used PostgreSQL instance settings when creating, so we don't lose them.