### PR TITLE
stable-rc: fix empty build failure section

### DIFF
--- a/kcidb/templates/stable_rc_build.j2
+++ b/kcidb/templates/stable_rc_build.j2
@@ -21,25 +21,22 @@
         {{- "\nBUILDS" }}
         {% set invalid_builds =
                 container.builds | selectattr("valid", "false") |
-                selectattr('origin', 'in', stable_rc_macros.selected_origins) | list %}
+                selectattr('origin', 'in', stable_rc_macros.selected_origins) |
+                rejectattr('architecture', 'none') | list %}
         {% set invalid_build_count = invalid_builds | length %}
         {% if invalid_builds %}
             {{- "\n    Failures" }}
             {% for origin, builds in invalid_builds|groupby("origin") %}
-                {% if origin in stable_rc_macros.selected_origins %}
-                    {% for build in builds %}
-                        {% if build.architecture %}
-                            {{- [('       -') + build.architecture,
-                                none if build.config_name is none else ('(' + build.config_name + ')')] |
-                                reject("none") | join(" ") -}}
-                            {{- "\n       Build detail: https://kcidb.kernelci.org/d/build/build?orgId=1&var-id=" + build.id}}
-                            {% if build.log_excerpt %}
-                                {{- "       Build error: " + build.log_error }}
-                            {% endif %}
-                        {% endif %}
-                    {% endfor %}
-                    {{- "       CI system: " + origin + "\n\n"-}}
-                {% endif %}
+                {% for build in builds %}
+                    {{- [('       -') + build.architecture,
+                        none if build.config_name is none else ('(' + build.config_name + ')')] |
+                        reject("none") | join(" ") -}}
+                    {{- "\n       Build detail: https://kcidb.kernelci.org/d/build/build?orgId=1&var-id=" + build.id}}
+                    {% if build.log_excerpt %}
+                        {{- "       Build error: " + build.log_error }}
+                    {% endif %}
+                {% endfor %}
+                {{- "       CI system: " + origin + "\n\n"-}}
             {% endfor %}
         {% else %}
             {{- "\n    No build failures found" }}


### PR DESCRIPTION
In some cases, build architecture information is not available for failed builds.
Do not list down such builds in the failures section as it won't be meaningful if such information is not present.