### PR TITLE
stable-rc: separate build configs with `, `

### DIFF
--- a/kcidb/templates/stable_rc.j2
+++ b/kcidb/templates/stable_rc.j2
@@ -1,2 +1,3 @@
 {# stable-rc macros #}
 {% set selected_origins = ['maestro', 'broonie'] %}
+{% set indent = "      " %}

--- a/kcidb/templates/stable_rc_build.j2
+++ b/kcidb/templates/stable_rc_build.j2
@@ -1,5 +1,6 @@
 {# Build template macros #}
 {% import "stable_rc.j2" as stable_rc_macros %}
+{% from "stable_rc.j2" import indent %}
 
 {% macro build_stats(container) %}
     {% if container.builds %}
@@ -28,15 +29,15 @@
             {{- "\n    Failures" }}
             {% for origin, builds in invalid_builds|groupby("origin") %}
                 {% for build in builds %}
-                    {{- [('       -') + build.architecture,
+                    {{- [( indent + '-') + build.architecture,
                         none if build.config_name is none else ('(' + build.config_name + ')')] |
                         reject("none") | join(" ") -}}
-                    {{- "\n       Build detail: https://kcidb.kernelci.org/d/build/build?orgId=1&var-id=" + build.id}}
+                    {{- "\n" + indent + "Build detail: https://kcidb.kernelci.org/d/build/build?orgId=1&var-id=" + build.id}}
                     {% if build.log_excerpt %}
-                        {{- "       Build error: " + build.log_error }}
+                        {{- indent + "Build error: " + build.log_error }}
                     {% endif %}
                 {% endfor %}
-                {{- "       CI system: " + origin + "\n\n"-}}
+                {{- indent + "CI system: " + origin + "\n\n"-}}
             {% endfor %}
         {% else %}
             {{- "\n    No build failures found" }}

--- a/kcidb/templates/stable_rc_test.j2
+++ b/kcidb/templates/stable_rc_test.j2
@@ -1,5 +1,6 @@
 {# Test macros #}
 {% import "stable_rc.j2" as stable_rc_macros %}
+{% from "stable_rc.j2" import indent %}
 
 {% macro tests_stats(container) %}
     {% if container.tests %}
@@ -23,13 +24,13 @@
                 selectattr('build.architecture', 'ne', None) | list %}
                 {% if boot_tests_info %}
                     {% for architecture, tests in boot_tests_info|groupby("build.architecture") %}
-                        {{- "\n      " + architecture }}:({{ tests|map(attribute="build.config_name") | unique | reject("none") | join("") }})
-                        {{- "\n      -" + tests|map(attribute="environment_misc.platform") | unique | join("\n      -") }}
-                        {{- "\n      CI system: " + origin}}
+                        {{- "\n" + indent + architecture }}:({{ tests|map(attribute="build.config_name") | unique | reject("none") | join(",\n" + indent + ' ' * (architecture + ":(") | length ) }})
+                        {{- "\n" + indent + "-" + tests|map(attribute="environment_misc.platform") | unique | join("\n      -") }}
+                        {{- "\n" + indent + "CI system: " + origin}}
                     {% endfor %}
                 {% else %}
-                    {{- "\n      Missing failure information. Sorry, we are working on improving report for this situation." }}
-                    {{- "\n      CI system: " + origin}}
+                    {{- "\n" + indent + "Missing failure information. Sorry, we are working on improving report for this situation." }}
+                    {{- "\n" + indent + "CI system: " + origin}}
                 {% endif %}
             {% endfor %}
         {% else %}


### PR DESCRIPTION
In the Boot failures section, use `, ` separator for different build configs for a build architecture for better readability.

Boot failures such as:
```
BOOT TESTS
Failures
          x86_64:(cros://chromeos-6.6/x86_64/chromeos-amd-stoneyridge.flavour.configcros://chromeos-6.6/x86_64/chromeos-intel-pineview.flavour.configx86_64_defconfig)
                -hp-x360-14a-cb0001xx-zork
                -asus-CM1400CXA-dalboz
                CI system: maestro
```
It would look like the below:
```
BOOT TESTS
    Failures
          x86_64:(cros://chromeos-6.6/x86_64/chromeos-amd-stoneyridge.flavour.config, cros://chromeos- 
6.6/x86_64/chromeos-intel-pineview.flavour.config, x86_64_defconfig)
                -hp-x360-14a-cb0001xx-zork
                -asus-CM1400CXA-dalboz
                CI system: maestro
```