### PR TITLE
cloud: Mute updates to relieve PostgreSQL temporarily

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -145,5 +145,6 @@ jobs:
             --grafana-anonymous
             --extra-cc=kernelci-results-staging@groups.io
             --cost-thresholds="$cost_thresholds_json"
+            --mute-updates
           )
           ./cloud deploy "${args[@]}" -v


### PR DESCRIPTION
This will stop notifications working on production.

CC @JenySadadia, am I right that we have no notifications sent to maintainers ATM?

I'll need to fix the performance, which I've been working on before LPC, but now I gotta get rid of COVID first.