### PR TITLE
Re-enable updates, and thus notifications

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,7 +122,6 @@ jobs:
             kernelci-production "playground"
             --smtp-mocked
             --optimize=2
-            --mute-updates
           )
           ./cloud deploy "${args[@]}" -v
       - name: Deploy Production
@@ -146,6 +145,5 @@ jobs:
             --grafana-anonymous
             --extra-cc=kernelci-results-staging@groups.io
             --cost-thresholds="$cost_thresholds_json"
-            --mute-updates
           )
           ./cloud deploy "${args[@]}" -v


### PR DESCRIPTION
Re-enable updates (and thus notification generation) in both production and playground. This merely records the state for the future deployments, as the updates were enabled manually earlier today.