### PR TITLE
Get last modified from data

### DIFF
--- a/kcidb/cloud/functions.sh
+++ b/kcidb/cloud/functions.sh
@@ -73,7 +73,6 @@ function functions_env() {
         [KCIDB_ARCHIVE_DATABASE]="$ar_database"
         [KCIDB_SAMPLE_DATABASE]="$sm_database"
         [KCIDB_DATABASE]="$database"
-        [KCIDB_DATABASE_LOAD_PERIOD_SEC]="180"
         [KCIDB_CLEAN_TEST_DATABASES]="$clean_test_databases"
         [KCIDB_EMPTY_TEST_DATABASES]="$empty_test_databases"
         [KCIDB_UPDATED_QUEUE_TOPIC]="$updated_topic"

--- a/kcidb/db/__init__.py
+++ b/kcidb/db/__init__.py
@@ -182,15 +182,19 @@ class Client(kcidb.orm.Source):
 
     def get_last_modified(self):
         """
-        Get the time the data in the connected database was last modified.
-        Can return the minimum timestamp constant, if the database is not
-        initialized or its data loading interface is not limited in the amount
-        of load() method calls.
+        Get the time data has arrived last into the driven database. Can
+        return the minimum timestamp constant, if the database is empty.
+        The database must be initialized.
 
         Returns:
             A timezone-aware datetime object representing the last
-            modification time.
+            data arrival time.
+
+        Raises:
+            NoTimestamps    - The database doesn't have row timestamps, and
+                              cannot determine the last data arrival time.
         """
+        assert self.is_initialized()
         last_modified = self.driver.get_last_modified()
         assert isinstance(last_modified, datetime.datetime)
         assert last_modified.tzinfo

--- a/kcidb/db/abstract.py
+++ b/kcidb/db/abstract.py
@@ -113,14 +113,17 @@ class Driver(ABC):
     @abstractmethod
     def get_last_modified(self):
         """
-        Get the time the data in the driven database was last modified.
-        Can return the minimum timestamp constant, if the database is not
-        initialized, or its data loading interface is not limited in the
-        amount of load() method calls.
+        Get the time data has arrived last into the driven database. Can
+        return the minimum timestamp constant, if the database is empty.
+        The database must be initialized.
 
         Returns:
             A timezone-aware datetime object representing the last
-            modification time.
+            data arrival time.
+
+        Raises:
+            NoTimestamps    - The database doesn't have row timestamps, and
+                              cannot determine the last data arrival time.
         """
 
     @abstractmethod

--- a/kcidb/db/mux.py
+++ b/kcidb/db/mux.py
@@ -291,14 +291,17 @@ class Driver(AbstractDriver):
 
     def get_last_modified(self):
         """
-        Get the time the data in the driven databases was last modified.
-        Can return the minimum timestamp constant, if the databases are not
-        initialized, or their data loading interface is not limited in the
-        amount of load() method calls.
+        Get the time data has arrived last into the driven database. Can
+        return the minimum timestamp constant, if the database is empty.
+        The database must be initialized.
 
         Returns:
             A timezone-aware datetime object representing the last
-            modification time.
+            data arrival time.
+
+        Raises:
+            NoTimestamps    - The database doesn't have row timestamps, and
+                              cannot determine the last data arrival time.
         """
         return max(driver.get_last_modified() for driver in self.drivers)
 

--- a/kcidb/db/null.py
+++ b/kcidb/db/null.py
@@ -118,14 +118,17 @@ class Driver(AbstractDriver):
 
     def get_last_modified(self):
         """
-        Get the time the data in the driven database was last modified.
-        Can return the minimum timestamp constant, if the database is not
-        initialized, or its data loading interface is not limited in the
-        amount of load() method calls.
+        Get the time data has arrived last into the driven database. Can
+        return the minimum timestamp constant, if the database is empty.
+        The database must be initialized.
 
         Returns:
             A timezone-aware datetime object representing the last
-            modification time.
+            data arrival time.
+
+        Raises:
+            NoTimestamps    - The database doesn't have row timestamps, and
+                              cannot determine the last data arrival time.
         """
         return datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
 

--- a/kcidb/db/sql/schema.py
+++ b/kcidb/db/sql/schema.py
@@ -343,6 +343,28 @@ class Table:
             ]
         )
 
+    def format_get_last_modified(self, name):
+        """
+        Format the "SELECT" command returning the timestamp of last data
+        written to the table, or NULL, if the table is empty.
+
+        Args:
+            name:           The name of the target table of the command.
+
+        Returns:
+            The formatted "SELECT" command, returning the timestamp in
+            "last_modified" column.
+
+        Raises:
+            NoTimestamps    - The table doesn't have row timestamps.
+        """
+        assert isinstance(name, str)
+        if not self.timestamp:
+            raise NoTimestamps("Table has no timestamp column")
+        return (
+            f"SELECT MAX({self.timestamp.name}) AS last_modified FROM {name}"
+        )
+
     def format_delete(self, name):
         """
         Format the "DELETE" command for emptying the table (removing all

--- a/kcidb/db/sqlite/v04_00.py
+++ b/kcidb/db/sqlite/v04_00.py
@@ -149,19 +149,6 @@ class Connection(AbstractConnection):
             finally:
                 cursor.close()
 
-    def get_last_modified(self):
-        """
-        Get the time the data in the connected database was last modified.
-        Can return the minimum timestamp constant, if the database is not
-        initialized or its data loading interface is not limited in the amount
-        of load() method calls.
-
-        Returns:
-            A timezone-aware datetime object representing the last
-            modification time.
-        """
-        return datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)
-
 
 class Schema(AbstractSchema):
     """SQLite database schema v4.0"""
@@ -905,3 +892,39 @@ class Schema(AbstractSchema):
         # Flip priority for the next load to maintain (rough)
         # parity with non-determinism of BigQuery's ANY_VALUE()
         self.conn.load_prio_db = not self.conn.load_prio_db
+
+    def get_last_modified(self):
+        """
+        Get the time data has arrived last into the driven database. Can
+        return the minimum timestamp constant, if the database is empty.
+        The database must be initialized.
+
+        Returns:
+            A timezone-aware datetime object representing the last
+            data arrival time.
+
+        Raises:
+            NoTimestamps    - The database doesn't have row timestamps, and
+                              cannot determine the last data arrival time.
+        """
+        statement = (
+            "SELECT MAX(last_modified) AS last_modified\n" +
+            "FROM (\n" +
+            textwrap.indent(
+                "\nUNION ALL\n".join(
+                    table_schema.format_get_last_modified(table_name)
+                    for table_name, table_schema in self.TABLES.items()
+                ),
+                " " * 4
+            ) + "\n) AS tables\n"
+        )
+        with self.conn:
+            cursor = self.conn.cursor()
+            try:
+                cursor.execute(statement)
+                timestamp = cursor.fetchone()[0]
+                if timestamp:
+                    return dateutil.parser.isoparse(timestamp)
+            finally:
+                cursor.close()
+        return datetime.datetime.min.replace(tzinfo=datetime.timezone.utc)

--- a/kcidb/test_db.py
+++ b/kcidb/test_db.py
@@ -2077,9 +2077,9 @@ def test_dump_limits(empty_database):
         assert client.dump() == io_schema.new()
     else:
         now = datetime.datetime.now(datetime.timezone.utc)
-        with pytest.raises(AssertionError):
+        with pytest.raises(kcidb.db.misc.NoTimestamps):
             client.dump(after=now)
-        with pytest.raises(AssertionError):
+        with pytest.raises(kcidb.db.misc.NoTimestamps):
             client.dump(until=now)
-        with pytest.raises(AssertionError):
+        with pytest.raises(kcidb.db.misc.NoTimestamps):
             client.dump(after=now, until=now)


### PR DESCRIPTION
Now that we're not going to be loading data in KCIDB directly from the submission queue, remove the rate throttling (which was inactive anyway due to particular database drivers being used).

Instead solely targeting the get_last_modified() method to databases which have load rate limit, make all of them support it, and return the maximum `_timestamp` value across all tables, if the schema has it.

Concerns #541