### PR TITLE
Codec summary report: update report link

### DIFF
--- a/kcidb/templates/fluster_revision_description.txt.j2
+++ b/kcidb/templates/fluster_revision_description.txt.j2
@@ -34,9 +34,9 @@ REVISION
 
 See complete and up-to-date report at:
     {% if ns.tree is not none %}
-        https://fresh2-kcidb-grafana-m6io3uhhiq-uc.a.run.app/d/bdviluqy6gv7kc/codecs?orgId=1&var-platform=All&var-datasource=default&var-git_commit_hash={{revision.git_commit_hash | urlencode }}&var-tree={{ns.tree}}&var-branch={{ns.branch}}
+        https://grafana.kernelci.org/d/codecs/codecs?orgId=1&var-platform=All&var-datasource=default&var-git_commit_hash={{revision.git_commit_hash | urlencode }}&var-tree={{ns.tree}}&var-branch={{ns.branch}}
     {% else %}
-        https://fresh2-kcidb-grafana-m6io3uhhiq-uc.a.run.app/d/bdviluqy6gv7kc/codecs?orgId=1&var-platform=All&var-datasource=default&var-git_commit_hash={{revision.git_commit_hash | urlencode }}
+        https://grafana.kernelci.org/d/codecs/codecs?orgId=1&var-platform=All&var-datasource=default&var-git_commit_hash={{revision.git_commit_hash | urlencode }}
     {% endif %}
 
 


### PR DESCRIPTION
As the grafana dashboard URL has changed, update test report URL accordingly.