### PR TITLE
Archive each table independently

### DIFF
--- a/kcidb/db/null.py
+++ b/kcidb/db/null.py
@@ -122,14 +122,15 @@ class Driver(AbstractDriver):
         The database must be initialized.
 
         Returns:
-            A timezone-aware datetime object representing the first
-            data arrival time, or None if the database is empty.
+            A dictionary of names of I/O object types (list names), which have
+            objects in the database, and timezone-aware datetime objects
+            representing the time the first one has arrived into the database.
 
         Raises:
             NoTimestamps    - The database doesn't have row timestamps, and
                               cannot determine data arrival time.
         """
-        return None
+        return {}
 
     def get_last_modified(self):
         """
@@ -137,14 +138,15 @@ class Driver(AbstractDriver):
         The database must be initialized.
 
         Returns:
-            A timezone-aware datetime object representing the last
-            data arrival time, or None if the database is empty.
+            A dictionary of names of I/O object types (list names), which have
+            objects in the database, and timezone-aware datetime objects
+            representing the time the last one has arrived into the database.
 
         Raises:
             NoTimestamps    - The database doesn't have row timestamps, and
                               cannot determine data arrival time.
         """
-        return None
+        return {}
 
     def dump_iter(self, objects_per_report, with_metadata, after, until):
         """
@@ -155,24 +157,30 @@ class Driver(AbstractDriver):
                                 report data, or zero for no limit.
             with_metadata:      True, if metadata fields should be dumped as
                                 well. False, if not.
-            after:              An "aware" datetime.datetime object specifying
-                                the latest (database server) time the data to
-                                be excluded from the dump should've arrived.
-                                The data after this time will be dumped.
-                                Can be None to have no limit on older data.
-            until:              An "aware" datetime.datetime object specifying
-                                the latest (database server) time the data to
-                                be dumped should've arrived.
-                                The data after this time will not be dumped.
-                                Can be None to have no limit on newer data.
+            after:              A dictionary of names of I/O object types
+                                (list names) and timezone-aware datetime
+                                objects specifying the latest time the
+                                corresponding objects should've arrived to be
+                                *excluded* from the dump. Any objects which
+                                arrived later will be *eligible* for dumping.
+                                Object types missing from this dictionary will
+                                not be limited.
+            until:              A dictionary of names of I/O object types
+                                (list names) and timezone-aware datetime
+                                objects specifying the latest time the
+                                corresponding objects should've arrived to be
+                                *included* into the dump. Any objects which
+                                arrived later will be *ineligible* for
+                                dumping. Object types missing from this
+                                dictionary will not be limited.
 
         Returns:
-            An iterator returning report JSON data adhering to the current I/O
-            schema version, each containing at most the specified number of
-            objects.
+            An iterator returning report JSON data adhering to the I/O
+            version of the database schema, each containing at most the
+            specified number of objects.
 
         Raises:
-            NoTimestamps    - Either "after" or "until" are not None, and
+            NoTimestamps    - Either "after" or "until" are not empty, and
                               the database doesn't have row timestamps.
         """
         del objects_per_report

--- a/kcidb/db/schematic.py
+++ b/kcidb/db/schematic.py
@@ -271,33 +271,32 @@ class Schema(ABC, metaclass=MetaSchema):
                                 report data, or zero for no limit.
             with_metadata:      True, if metadata fields should be dumped as
                                 well. False, if not.
-            after:              An "aware" datetime.datetime object specifying
-                                the latest (database server) time the data to
-                                be excluded from the dump should've arrived.
-                                The data after this time will be dumped.
-                                Can be None to have no limit on older data.
-            until:              An "aware" datetime.datetime object specifying
-                                the latest (database server) time the data to
-                                be dumped should've arrived.
-                                The data after this time will not be dumped.
-                                Can be None to have no limit on newer data.
+            after:              A dictionary of names of I/O object types
+                                (list names) and timezone-aware datetime
+                                objects specifying the latest time the
+                                corresponding objects should've arrived to be
+                                *excluded* from the dump. Any objects which
+                                arrived later will be *eligible* for dumping.
+                                Object types missing from this dictionary will
+                                not be limited.
+            until:              A dictionary of names of I/O object types
+                                (list names) and timezone-aware datetime
+                                objects specifying the latest time the
+                                corresponding objects should've arrived to be
+                                *included* into the dump. Any objects which
+                                arrived later will be *ineligible* for
+                                dumping. Object types missing from this
+                                dictionary will not be limited.
 
         Returns:
-            An iterator returning report JSON data adhering to the current
-            database schema's I/O schema version, each containing at most the
+            An iterator returning report JSON data adhering to the I/O
+            version of the database schema, each containing at most the
             specified number of objects.
 
         Raises:
-            NoTimestamps    - Either "after" or "until" are not None, and
+            NoTimestamps    - Either "after" or "until" are not empty, and
                               the database doesn't have row timestamps.
         """
-        assert isinstance(objects_per_report, int)
-        assert objects_per_report >= 0
-        assert isinstance(with_metadata, bool)
-        assert after is None or \
-            isinstance(after, datetime.datetime) and after.tzinfo
-        assert until is None or \
-            isinstance(until, datetime.datetime) and until.tzinfo
 
     # We can live with this for now, pylint: disable=too-many-arguments
     # Or if you prefer, pylint: disable=too-many-positional-arguments
@@ -375,8 +374,9 @@ class Schema(ABC, metaclass=MetaSchema):
         The database must be initialized.
 
         Returns:
-            A timezone-aware datetime object representing the first
-            data arrival time, or None if the database is empty.
+            A dictionary of names of I/O object types (list names), which have
+            objects in the database, and timezone-aware datetime objects
+            representing the time the first one has arrived into the database.
 
         Raises:
             NoTimestamps    - The database doesn't have row timestamps, and
@@ -390,8 +390,9 @@ class Schema(ABC, metaclass=MetaSchema):
         The database must be initialized.
 
         Returns:
-            A timezone-aware datetime object representing the last
-            data arrival time, or None if the database is empty.
+            A dictionary of names of I/O object types (list names), which have
+            objects in the database, and timezone-aware datetime objects
+            representing the time the last one has arrived into the database.
 
         Raises:
             NoTimestamps    - The database doesn't have row timestamps, and
@@ -567,8 +568,9 @@ class Driver(AbstractDriver, metaclass=MetaDriver):
         The database must be initialized.
 
         Returns:
-            A timezone-aware datetime object representing the first
-            data arrival time, or None if the database is empty.
+            A dictionary of names of I/O object types (list names), which have
+            objects in the database, and timezone-aware datetime objects
+            representing the time the first one has arrived into the database.
 
         Raises:
             NoTimestamps    - The database doesn't have row timestamps, and
@@ -583,8 +585,9 @@ class Driver(AbstractDriver, metaclass=MetaDriver):
         The database must be initialized.
 
         Returns:
-            A timezone-aware datetime object representing the last
-            data arrival time, or None if the database is empty.
+            A dictionary of names of I/O object types (list names), which have
+            objects in the database, and timezone-aware datetime objects
+            representing the time the last one has arrived into the database.
 
         Raises:
             NoTimestamps    - The database doesn't have row timestamps, and
@@ -669,34 +672,47 @@ class Driver(AbstractDriver, metaclass=MetaDriver):
                                 report data, or zero for no limit.
             with_metadata:      True, if metadata fields should be dumped as
                                 well. False, if not.
-            after:              An "aware" datetime.datetime object specifying
-                                the latest (database server) time the data to
-                                be excluded from the dump should've arrived.
-                                The data after this time will be dumped.
-                                Can be None to have no limit on older data.
-            until:              An "aware" datetime.datetime object specifying
-                                the latest (database server) time the data to
-                                be dumped should've arrived.
-                                The data after this time will not be dumped.
-                                Can be None to have no limit on newer data.
+            after:              A dictionary of names of I/O object types
+                                (list names) and timezone-aware datetime
+                                objects specifying the latest time the
+                                corresponding objects should've arrived to be
+                                *excluded* from the dump. Any objects which
+                                arrived later will be *eligible* for dumping.
+                                Object types missing from this dictionary will
+                                not be limited.
+            until:              A dictionary of names of I/O object types
+                                (list names) and timezone-aware datetime
+                                objects specifying the latest time the
+                                corresponding objects should've arrived to be
+                                *included* into the dump. Any objects which
+                                arrived later will be *ineligible* for
+                                dumping. Object types missing from this
+                                dictionary will not be limited.
 
         Returns:
-            An iterator returning report JSON data adhering to the schema's
-            I/O schema version, each containing at most the specified number
-            of objects.
+            An iterator returning report JSON data adhering to the I/O
+            version of the database schema, each containing at most the
+            specified number of objects.
 
         Raises:
-            NoTimestamps    - Either "after" or "until" are not None, and
+            NoTimestamps    - Either "after" or "until" are not empty, and
                               the database doesn't have row timestamps.
         """
+        assert self.is_initialized()
+        io_schema = self.get_schema()[1]
         assert isinstance(objects_per_report, int)
         assert objects_per_report >= 0
         assert isinstance(with_metadata, bool)
-        assert after is None or \
-            isinstance(after, datetime.datetime) and after.tzinfo
-        assert until is None or \
-            isinstance(until, datetime.datetime) and until.tzinfo
-        assert self.is_initialized()
+        assert isinstance(after, dict) and all(
+            obj_list_name in io_schema.id_fields and
+            isinstance(ts, datetime.datetime) and ts.tzinfo
+            for obj_list_name, ts in after.items()
+        )
+        assert isinstance(until, dict) and all(
+            obj_list_name in io_schema.id_fields and
+            isinstance(ts, datetime.datetime) and ts.tzinfo
+            for obj_list_name, ts in until.items()
+        )
         return self.schema.dump_iter(objects_per_report, with_metadata,
                                      after, until)
 

--- a/kcidb/db/sql/schema.py
+++ b/kcidb/db/sql/schema.py
@@ -352,8 +352,9 @@ class Table:
             name:           The name of the target table of the command.
 
         Returns:
-            The formatted "SELECT" command, returning the timestamp in
-            "first_modified" column.
+            The formatted "SELECT" command and its parameters container.
+            The "SELECT" command returns the table name in "table_name",
+            and the timestamp in "first_modified" columns.
 
         Raises:
             NoTimestamps    - The table doesn't have row timestamps.
@@ -362,7 +363,10 @@ class Table:
         if not self.timestamp:
             raise NoTimestamps("Table has no timestamp column")
         return (
-            f"SELECT MIN({self.timestamp.name}) AS first_modified FROM {name}"
+            f"SELECT {self.placeholder} AS table_name, "
+            f"MIN({self.timestamp.name}) AS first_modified "
+            f"FROM {name}",
+            (name,)
         )
 
     def format_get_last_modified(self, name):
@@ -374,8 +378,9 @@ class Table:
             name:           The name of the target table of the command.
 
         Returns:
-            The formatted "SELECT" command, returning the timestamp in
-            "last_modified" column.
+            The formatted "SELECT" command and its parameters container.
+            The "SELECT" command returns the table name in "table_name",
+            and the timestamp in "last_modified" columns.
 
         Raises:
             NoTimestamps    - The table doesn't have row timestamps.
@@ -384,7 +389,10 @@ class Table:
         if not self.timestamp:
             raise NoTimestamps("Table has no timestamp column")
         return (
-            f"SELECT MAX({self.timestamp.name}) AS last_modified FROM {name}"
+            f"SELECT {self.placeholder} AS table_name, "
+            f"MAX({self.timestamp.name}) AS last_modified "
+            f"FROM {name}",
+            (name,)
         )
 
     def format_delete(self, name):

--- a/kcidb/test_db.py
+++ b/kcidb/test_db.py
@@ -451,27 +451,37 @@ def test_get_modified(clean_database):
     # Check a post-timestamp schema version
     time.sleep(1)
     client.init()
-    timestamp = client.get_first_modified()
-    assert timestamp is None
-    timestamp = client.get_last_modified()
-    assert timestamp is None
+    io_schema = client.get_schema()[1]
+    timestamps = client.get_first_modified()
+    assert timestamps == {}
+    timestamps = client.get_last_modified()
+    assert timestamps == {}
     before_load = client.get_current_time()
     client.load(COMPREHENSIVE_IO_DATA)
 
     first_modified = client.get_first_modified()
     last_modified = client.get_last_modified()
 
-    assert first_modified is not None
-    assert isinstance(first_modified, datetime.datetime)
-    assert first_modified.tzinfo is not None
-    assert first_modified >= before_load
+    assert isinstance(first_modified, dict)
+    assert set(io_schema.id_fields) == set(first_modified)
+    assert all(
+        isinstance(t, datetime.datetime) and
+        t.tzinfo is not None and
+        t >= before_load
+        for t in first_modified.values()
+    )
 
-    assert last_modified is not None
-    assert isinstance(last_modified, datetime.datetime)
-    assert last_modified.tzinfo is not None
-    assert last_modified >= before_load
+    assert isinstance(last_modified, dict)
+    assert set(io_schema.id_fields) == set(last_modified)
+    assert all(
+        isinstance(t, datetime.datetime) and
+        t.tzinfo is not None and
+        t >= before_load
+        for t in first_modified.values()
+    )
 
-    assert last_modified >= first_modified
+    assert all(t >= first_modified[n] for n, t in last_modified.items())
+
     client.cleanup()
 
 

--- a/test_main.py
+++ b/test_main.py
@@ -410,7 +410,7 @@ def test_archive(empty_deployment):
     op_client.load(data_now, with_metadata=True)
     # Trigger and wait for archival (ignore possibility of actual trigger)
     publisher.publish({})
-    time.sleep(30)
+    time.sleep(60)
     # Check data_now doesn't end up in the archive DB
     assert ar_schema.count(ar_client.dump()) == 0
 
@@ -418,7 +418,7 @@ def test_archive(empty_deployment):
     op_client.load(op_schema.merge(data_3w, [data_4w]), with_metadata=True)
     # Trigger and wait for archival (ignore possibility of actual trigger)
     publisher.publish({})
-    time.sleep(30)
+    time.sleep(60)
     # Check data_4w is in the archive database
     dump = ar_client.dump()
     assert all(
@@ -434,7 +434,7 @@ def test_archive(empty_deployment):
     ), "Some three-week old data in the archive"
     # Trigger and wait for another archival (ignore chance of actual trigger)
     publisher.publish({})
-    time.sleep(30)
+    time.sleep(60)
     # Check data_3w is now in the archive database
     dump = ar_client.dump()
     assert all(


### PR DESCRIPTION
At the moment all operational tables are archived using a single timestamp for the lower boundary, which either loses us data, if they're uneven, or forces us to load duplicates to make sure we don't lose anything. This is because some databases don't support atomic modifications of multiple tables at once.

Work that around, by assigning separate time ranges to separate tables, when dumping.

Concerns #541 