### PR TITLE
fluster report: specify data source in the report link

### DIFF
--- a/kcidb/templates/fluster_revision_description.txt.j2
+++ b/kcidb/templates/fluster_revision_description.txt.j2
@@ -34,9 +34,9 @@ REVISION
 
 See complete and up-to-date report at:
     {% if ns.tree is not none %}
-        https://grafana.kernelci.org/d/codecs/codecs?orgId=1&var-platform=All&var-datasource=default&var-git_commit_hash={{revision.git_commit_hash | urlencode }}&var-tree={{ns.tree}}&var-branch={{ns.branch}}
+        https://grafana.kernelci.org/d/codecs/codecs?orgId=1&var-platform=All&var-datasource=production&var-git_commit_hash={{revision.git_commit_hash | urlencode }}&var-tree={{ns.tree}}&var-branch={{ns.branch}}
     {% else %}
-        https://grafana.kernelci.org/d/codecs/codecs?orgId=1&var-platform=All&var-datasource=default&var-git_commit_hash={{revision.git_commit_hash | urlencode }}
+        https://grafana.kernelci.org/d/codecs/codecs?orgId=1&var-platform=All&var-datasource=production&var-git_commit_hash={{revision.git_commit_hash | urlencode }}
     {% endif %}
 
 


### PR DESCRIPTION
`var-datasource=default` in the fluster test summary link leads to `playground` rather than `production` on the dashboard. Specify the exact data source instead of relying on the default value.