### PR TITLE
Codec summary report: fix report formatting

### DIFF
--- a/kcidb/templates/fluster_test.j2
+++ b/kcidb/templates/fluster_test.j2
@@ -33,9 +33,11 @@
             {% set _ = statuses_counts.update({test.status: count}) %}
             {% set _ = titles_statuses_counts.update({title: statuses_counts}) %}
             {% set _ = boards_titles_statuses_counts.update({board: titles_statuses_counts}) %}
-            {{ display_test_summary(boards_titles_statuses_counts, file_system) }}
         {% endif %}
     {% endfor %}
+    {% if boards_titles_statuses_counts %}
+        {{ display_test_summary(boards_titles_statuses_counts, file_system) }}
+    {% endif %}
 {% endmacro %}
 
 {% macro display_test_summary(boards_titles_statuses_counts, file_system) %}


### PR DESCRIPTION
Fix the issue in fluster test report formatting.
It currenly reports all the tests one by one instead of the summary with file system.

Fixes: 6656ef2("codec-summary report: include chromeos fluster tests")