### PR TITLE
cloud: Bump archival RAM to (the max of) 8GB

### DIFF
--- a/kcidb/cloud/functions.sh
+++ b/kcidb/cloud/functions.sh
@@ -181,7 +181,7 @@ function functions_deploy() {
                     archive true \
                     --env-vars-file "$env_yaml_file" \
                     --trigger-topic "${archive_trigger_topic}" \
-                    --memory 4096MB \
+                    --memory 8192MB \
                     --max-instances=1 \
                     --timeout 540
 


### PR DESCRIPTION
Bump the RAM allocated to the data archival cloud function from 4GB to 8GB, so we avoid aborting on out-of-memory when transferring 12 hours of data at a time.

It could be that BigQuery is accumulating memory use over time and running out, despite us calling gc.collect() after every transfer, but I don't have the time to pursue this further.