### PR TITLE
Fix empty reports: `stable-rc`, `stable-rt`, `fluster`

### DIFF
--- a/kcidb/monitor/subscriptions/codec_summary.py
+++ b/kcidb/monitor/subscriptions/codec_summary.py
@@ -27,6 +27,19 @@ def match_revision(revision):
     ):
         return ()
 
+    # Don't generate summary report if revision has fluster job nodes
+    # and doesn't have any specific test nodes as codec summary
+    # report is intended to provide stats of number of passed, failed, and
+    # total tests of fluster jobs
+    # Below is the maestro convention for fluster tests:
+    # Job node path: "fluster.chromeos.v4l2.gstreamer_vp9"
+    # Test node path: "fluster.chromeos.v4l2.gstreamer_vp9.<test-name>"
+    if all(
+        len(t.path.split('.')) <= 4
+        for t in revision.tests_root["fluster"].tests
+    ):
+        return ()
+
     # Send notification 3 hours after a revision is created/updated
     return (Message(
         subject='KernelCI report for fluster tests: '

--- a/kcidb/monitor/subscriptions/linux_stable_rc.py
+++ b/kcidb/monitor/subscriptions/linux_stable_rc.py
@@ -16,11 +16,12 @@ def match_revision(revision):
     if repo_url not in revision.repo_branch_checkouts:
         return ()
 
-    if revision.builds_valid is None:
-        return ()
+    selected_origins = {'maestro', 'broonie'}
 
-    # If the revision is not from 'maestro' or 'broonie' origin
-    if not {c.origin for c in revision.checkouts} & {'maestro', 'broonie'}:
+    # If no builds found from 'maestro' or 'broonie' origin
+    # or status is unknown for all the builds
+    if all(b.origin not in selected_origins or b.valid is None
+           for b in revision.builds):
         return ()
 
     # Send notification 3 hours after a revision is created/updated

--- a/kcidb/monitor/subscriptions/linux_stable_rt.py
+++ b/kcidb/monitor/subscriptions/linux_stable_rt.py
@@ -16,11 +16,12 @@ def match_revision(revision):
     if repo_url not in revision.repo_branch_checkouts:
         return ()
 
-    if revision.builds_valid is None:
-        return ()
+    selected_origins = {'maestro', 'broonie'}
 
-    # If the revision is not from 'maestro' or 'broonie' origin
-    if not {c.origin for c in revision.checkouts} & {'maestro', 'broonie'}:
+    # If no builds found from 'maestro' or 'broonie' origin
+    # or status is unknown for all the builds
+    if all(b.origin not in selected_origins or b.valid is None
+           for b in revision.builds):
         return ()
 
     # Send notification 3 hours after a revision is created/updated


### PR DESCRIPTION
Add a check to verify if there are builds from selected origins before generating the report.