### PR TITLE
(tests.yaml): Remove kver tests

### DIFF
--- a/tests.yaml
+++ b/tests.yaml
@@ -78,12 +78,6 @@ fwts:
 jcstress:
   title: The Java Concurrency Stress tests
   home: https://github.com/openjdk/jcstress
-kernelci_kver:
-  title: Kernel Version test
-  home: https://github.com/kernelci/kernelci-pipeline/blob/main/config/runtime/kver.jinja2
-  description: |
-    Checks kernel version using "git describe" and verify it with kernel
-    Makefile version.
 kernelci_sleep:
   title: KernelCI sleep test
   home: https://github.com/kernelci/kernelci-core/blob/main/config/runtime/tests/sleep.jinja2


### PR DESCRIPTION
This is more "canary" or PoC test, than real test, also by some reason it often gives false positives, not adding any value.
We decided it is better to remove it.