### PR TITLE
Disable posting object/URL updates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,6 +140,8 @@ jobs:
           ]'
           declare -a args=(
             kernelci-production ""
+            --mute-updates
+            --mute-url-updates
             --grafana-url=https://kcidb.kernelci.org
             --grafana-public
             --grafana-anonymous

--- a/cloud
+++ b/cloud
@@ -86,6 +86,7 @@ function app_deploy() {
 #       --optimize=PYTHONOPTIMIZE
 #       --heavy-asserts=true|false
 #       --updated-publish=true|false
+#       --updated-urls-publish=true|false
 #       --submitters=WORDS
 #       --cost-thresholds=JSON
 #       --grafana-url=URL
@@ -107,6 +108,7 @@ function execute_command() {
                           optimize \
                           heavy_asserts \
                           updated_publish \
+                          updated_urls_publish \
                           submitters \
                           cost_thresholds \
                           grafana_url \
@@ -299,6 +301,7 @@ function execute_command() {
         --new-topic="$new_topic"
         --new-load-subscription="$new_load_subscription"
         --updated-publish="$updated_publish"
+        --updated-urls-publish="$updated_urls_publish"
         --updated-topic="$updated_topic"
         --load-queue-trigger-topic="$load_queue_trigger_topic"
         --purge-db-trigger-topic="$purge_db_trigger_topic"
@@ -553,6 +556,8 @@ function usage_deploy() {
     echo "              Enable heavy assertion checking in deployment."
     echo "    --mute-updates"
     echo "              Disable posting updates about loaded data."
+    echo "    --mute-url-updates"
+    echo "              Disable posting updated artifact URLs."
     echo "    --test"
     echo "              Deploy test resources in various sections."
     echo "    --submitter=NAME"
@@ -609,6 +614,8 @@ function usage_env() {
     echo "              Enable heavy assertion checking in deployment."
     echo "    --mute-updates"
     echo "              Disable posting updates about loaded data."
+    echo "    --mute-url-updates"
+    echo "              Disable posting updated artifact URLs."
     echo "    --test"
     echo "              Enable various test resources."
     echo ""
@@ -648,6 +655,8 @@ function usage_shell() {
     echo "              Enable heavy assertion checking in deployment."
     echo "    --mute-updates"
     echo "              Expect updates about loaded data to be disabled."
+    echo "    --mute-url-updates"
+    echo "              Expect posting of artifact URL updates to be disabled."
     echo "    --test"
     echo "              Expect various test resources to be deployed."
     echo ""
@@ -789,7 +798,8 @@ function execute() {
         fi
         if [[ $command == @(deploy|env|shell) ]]; then
             getopt_longopts+=",extra-cc:,smtp-to-addrs:"
-            getopt_longopts+=",log-level:,optimize:,heavy-asserts,mute-updates"
+            getopt_longopts+=",log-level:,optimize:,heavy-asserts"
+            getopt_longopts+=",mute-updates,mute-url-updates"
             if [[ $command == env ]]; then
                 getopt_longopts+=",format:"
             fi
@@ -827,6 +837,7 @@ function execute() {
     declare optimize=""
     declare heavy_asserts="false"
     declare updated_publish="true"
+    declare updated_urls_publish="true"
     declare -a submitters=()
     declare format="yaml"
     declare cost_thresholds="[]"
@@ -848,6 +859,7 @@ function execute() {
             --optimize) optimize="$2"; shift 2;;
             --heavy-asserts) heavy_asserts="true"; shift;;
             --mute-updates) updated_publish="false"; shift;;
+            --mute-url-updates) updated_urls_publish="false"; shift;;
             --test) test="true"; shift;;
             --format) format="$2"; shift 2;;
             --submitter) submitters+=("$2"); shift 2;;
@@ -917,6 +929,7 @@ function execute() {
                     --optimize="$optimize" \
                     --heavy-asserts="$heavy_asserts" \
                     --updated-publish="$updated_publish" \
+                    --updated-urls-publish="$updated_urls_publish" \
                     --submitters="${submitters[*]@Q}" \
                     --cost-thresholds="$cost_thresholds" \
                     --grafana-url="$grafana_url" \

--- a/doc/administrator_guide.md
+++ b/doc/administrator_guide.md
@@ -2,7 +2,7 @@
 title: "Administrator guide"
 date: 2021-11-18
 draft: false
-wieght: 50
+weight: 50
 description: "Deploying, maintaining, and upgrading a KCIDB service installation"
 ---
 

--- a/kcidb/cloud/functions.sh
+++ b/kcidb/cloud/functions.sh
@@ -15,6 +15,7 @@ declare _FUNCTIONS_SH=
 #       --heavy-asserts=true|false
 #       --new-topic=NAME --new-load-subscription=NAME
 #       --updated-publish=true|false
+#       --updated-urls-publish=true|false
 #       --updated-topic=NAME
 #       --load-queue-trigger-topic=NAME
 #       --purge-db-trigger-topic=NAME
@@ -41,7 +42,9 @@ function functions_env() {
                           optimize \
                           heavy_asserts \
                           new_topic new_load_subscription \
-                          updated_publish updated_topic \
+                          updated_publish \
+                          updated_urls_publish \
+                          updated_topic \
                           load_queue_trigger_topic \
                           purge_db_trigger_topic \
                           archive_trigger_topic \
@@ -108,6 +111,9 @@ function functions_env() {
     fi
     if "$updated_publish"; then
         env[KCIDB_UPDATED_PUBLISH]="1"
+    fi
+    if "$updated_urls_publish"; then
+        env[KCIDB_UPDATED_URLS_PUBLISH]="1"
     fi
     if [ "$format" == "yaml" ]; then
         # Silly Python and its significant whitespace


### PR DESCRIPTION
Disable posting object/URL updates to the corresponding queues to reduce Cloud Function load, which saw a cost hike.

This will disable notifications and trial artifact archival.