### PR TITLE
pytest: ignore pkg_resource warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
+          cache: 'pip'
           python-version: ${{ matrix.python-version }}
       - name: Check setup.py and requirements.txt are consistent
         run: |
@@ -67,6 +68,7 @@ jobs:
             pytest --tb=native --durations=0 --durations-min=1
         env:
           KCIDB_HOOKS: "pre-commit"
+          PYTHONWARNINGS: "ignore:pkg_resources is deprecated:UserWarning"
 
   check_auxiliary_files:
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 filterwarnings =
-    ignore:Deprecated call to `pkg_resources.declare_namespace\('google'\)`:DeprecationWarning
+    ignore:Deprecated call to `pkg_resources.declare_namespace:DeprecationWarning
+    ignore:pkg_resources is deprecated:UserWarning


### PR DESCRIPTION
The unit tests are still failing due to handling stderr directly. As a patchwork, ignore more warnings until we rewrite the tests.