### PR TITLE
chore: add prometheus_client to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ python-dateutil
 cached-property
 kcidb-io@git+https://github.com/kernelci/kcidb-io.git
 jq@git+https://github.com/kernelci/jq.py.git@1.7.0.post1
+prometheus_client

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setuptools.setup(
         "cached-property",
         "kcidb-io@git+https://github.com/kernelci/kcidb-io.git",
         "jq@git+https://github.com/kernelci/jq.py.git@1.7.0.post1",
+        "prometheus_client"
     ],
     extras_require=dict(
         dev=[


### PR DESCRIPTION
This PR adds prometheus_client to requirements.txt to allow using prometheus counters inside code

Related to https://github.com/kernelci/kcidb-ng/pull/61